### PR TITLE
Documentation: Add info on vcpkg installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Here you find more detailed information on:
 * [Versioning](#Versioning)
   * [Version number examples](#Version-number-examples)
 
+## Installing with vcpkg
+
+GUL14 is available from the [vcpkg](https://vcpkg.io/) package manager. Once you have
+vcpkg installed, just run:
+
+        vcpkg install gul14
 
 ## Building <a name="Building"></a>
 

--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -79,6 +79,13 @@ namespace gul14 {
  * GUL14 requires at least C++14. It works fine with newer versions of the standard, but
  * uses its own backport types (e.g. gul14::string_view) in function interfaces.
  *
+ * \section installation Installation
+ *
+ * If you are using the [vcpkg](https://vcpkg.io/) package manager, you can install the
+ * library simply by running \verbatim vcpkg install gul14\endverbatim. Otherwise, you may
+ * have to build and install it manually. Have a look at the
+ * [readme file on GitHub](https://github.com/gul-cpp/gul14/blob/main/README.md).
+ *
  * \section source_code Obtaining the Source Code
  *
  * You can browse or clone the source code at https://github.com/gul-cpp/gul14.git.


### PR DESCRIPTION
vcpkg has recently accepted a [portfile for GUL14](https://github.com/microsoft/vcpkg/commit/fd69fb296475fb8c5ef5e3daec57258e5c7ba06d), so the library can now be installed via "vcpkg install gul14". It is probably good to advertise this in a new "installation" section in both the README and the Doxygen documentation.