### PR TITLE
Documentation/small documentation improvements

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -116,6 +116,7 @@ namespace gul14 {
  *
  * \subsection v2_6 Version 2.6
  *
+ * - *Released with DOOCS 21.12.0–22.6.1*
  * - Add safe_string()
  * - Add hex_string()
  * - Add IsContainerLike<>

--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -82,8 +82,9 @@ namespace gul14 {
  * \section installation Installation
  *
  * If you are using the [vcpkg](https://vcpkg.io/) package manager, you can install the
- * library simply by running \verbatim vcpkg install gul14\endverbatim. Otherwise, you may
- * have to build and install it manually. Have a look at the
+ * library simply by running:
+ * \verbatim vcpkg install gul14\endverbatim
+ * Otherwise, you may have to build and install it manually. Have a look at the
  * [readme file on GitHub](https://github.com/gul-cpp/gul14/blob/main/README.md).
  *
  * \section source_code Obtaining the Source Code


### PR DESCRIPTION
Two minor improvements to the Doxygen page:
* Correct punctuation (\verbatim ... \endverbatim creates a separate paragraph in Doxygen, so adding a full stop after it looks weird)
* Add information on DOOCS releases 21.12.0-22.6.1