### PR TITLE
Add gcd() and lcm()

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -146,6 +146,7 @@ namespace gul14 {
  * \subsection v2_7 Version 2.7
  *
  * - Add repeat()
+ * - Add gcd() and lcm()
  * - Add Howard Hinnant's date.h header
  *
  * \subsection v2_6 Version 2.6
@@ -509,6 +510,14 @@ namespace gul14 {
  *
  * clamp():
  *     Coerce a value to be within a given range.
+ *
+ * <h4>Greatest Common Divisor & Least Common Multiple</h4>
+ *
+ * gcd():
+ *     Calculate the greatest common divisor of two integers.
+ *
+ * lcm():
+ *     Calculate the least common multiple of two integers.
  *
  * <h4>Converting to Numbers</h4>
  *

--- a/include/gul14/gcd_lcm.h
+++ b/include/gul14/gcd_lcm.h
@@ -23,6 +23,7 @@
 #ifndef GUL14_GCD_LCM_H_
 #define GUL14_GCD_LCM_H_
 
+#include <cstdint>
 #include <type_traits>
 #include "gul14/internal.h"
 #include "gul14/num_util.h"
@@ -129,7 +130,7 @@ lcm(IntTypeA a, IntTypeB b)
     if (a == 0 && b == 0)
         return CommonType{ 0 };
 
-    return static_cast<CommonType>(gul14::abs(a * b) / gcd(a, b));
+    return static_cast<CommonType>(gul14::abs((a / gcd(a, b)) * b));
 }
 
 } // namespace gul14

--- a/include/gul14/gcd_lcm.h
+++ b/include/gul14/gcd_lcm.h
@@ -1,6 +1,6 @@
 /**
  * \file    gcd_lcm.h
- * \brief   Declarations of greatest_common_divisor() and least_common_multiple().
+ * \brief   Declarations of gcd() and lcm().
  * \authors \ref contributors
  * \date    Created on 5 August 2022
  *
@@ -23,7 +23,6 @@
 #ifndef GUL14_GCD_LCM_H_
 #define GUL14_GCD_LCM_H_
 
-#include <cstdint>
 #include <type_traits>
 #include "gul14/internal.h"
 #include "gul14/num_util.h"
@@ -31,8 +30,7 @@
 namespace gul14 {
 
 /**
- * Calculate the greatest common divisor (gcd) of two integers using the Euclidean
- * algorithm.
+ * Calculate the greatest common divisor of two integers using the Euclidean algorithm.
  *
  * If both numbers are zero, the function returns zero. Otherwise, the result is a
  * positive integer.

--- a/include/gul14/gcd_lcm.h
+++ b/include/gul14/gcd_lcm.h
@@ -1,0 +1,137 @@
+/**
+ * \file    gcd_lcm.h
+ * \brief   Declarations of greatest_common_divisor() and least_common_multiple().
+ * \authors \ref contributors
+ * \date    Created on 5 August 2022
+ *
+ * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef GUL14_GCD_LCM_H_
+#define GUL14_GCD_LCM_H_
+
+#include <type_traits>
+#include "gul14/internal.h"
+#include "gul14/num_util.h"
+
+namespace gul14 {
+
+/**
+ * Calculate the greatest common divisor (gcd) of two integers using the Euclidean
+ * algorithm.
+ *
+ * If both numbers are zero, the function returns zero. Otherwise, the result is a
+ * positive integer.
+ *
+ * \code
+ * int greatest_common_divisor = gcd(10, 15); // returns 5
+ * \endcode
+ *
+ * \returns the least common multiple of the two numbers, represented as an integer type
+ *          (`std::common_type_t<IntTypeA, IntTypeB>`) that both inputs can implicitly be
+ *          converted to. If either a, b, or the result can not be represented by that
+ *          type, the result is undefined.
+ *
+ * \note
+ * Unlike `std::gcd()` from C++17, the GUL14 version cannot be used with integers of
+ * different signedness. This avoids undefined behavior when mixing unsigned integers with
+ * negative signed values:
+ * \code
+ * // C++17 gcd(): Undefined behavior - the common type is `unsigned int` and -5 has no
+ * // representation in that type
+ * auto bad_result = std::gcd(10u, -5);
+ *
+ * // GUL14 gcd(): Does not compile
+ * auto static_assertion_failure = gul14::gcd(10u, -5);
+ * \endcode
+ *
+ * \since GUL 2.7
+ */
+template <typename IntTypeA, typename IntTypeB>
+constexpr inline auto
+gcd(IntTypeA a, IntTypeB b)
+{
+    static_assert(std::is_integral<IntTypeA>::value and std::is_integral<IntTypeB>::value,
+        "gcd() arguments must be integers");
+
+    static_assert(std::is_signed<IntTypeA>::value == std::is_signed<IntTypeB>::value,
+        "gcd() arguments must have the same signedness");
+
+    using CommonType = std::common_type_t<IntTypeA, IntTypeB>;
+
+    auto c = gul14::abs(static_cast<CommonType>(a));
+    auto d = gul14::abs(static_cast<CommonType>(b));
+
+    while (d != 0)
+    {
+        CommonType tmp = d;
+        d = c % d;
+        c = tmp;
+    }
+
+    return c;
+}
+
+/**
+ * Calculate the least common multiple of two integers.
+ *
+ * If both numbers are zero, the function returns zero. Otherwise, the result is a
+ * positive integer.
+ * \code
+ * int least_common_multiple = lcm(10, 15); // returns 30
+ * \endcode
+ *
+ * \returns the least common multiple of the two numbers, represented as an integer type
+ *          (`std::common_type_t<IntTypeA, IntTypeB>`) that both inputs can implicitly be
+ *          converted to. If either a, b, or the result can not be represented by that
+ *          type, the result is undefined.
+ *
+ * \note
+ * Unlike `std::lcm()` from C++17, the GUL14 version cannot be used with integers of
+ * different signedness. This avoids undefined behavior when mixing unsigned integers with
+ * negative signed values:
+ * \code
+ * // C++17 lcm(): Undefined behavior - the common type is `unsigned int` and -5 has no
+ * // representation in that type
+ * auto bad_result = std::lcm(10u, -5);
+ *
+ * // GUL14 lcm(): Does not compile
+ * auto static_assertion_failure = gul14::lcm(10u, -5);
+ * \endcode
+ *
+ * \since GUL 2.7
+ */
+template <typename IntTypeA, typename IntTypeB>
+constexpr inline auto
+lcm(IntTypeA a, IntTypeB b)
+{
+    static_assert(std::is_integral<IntTypeA>::value and std::is_integral<IntTypeB>::value,
+        "lcm() arguments must be integers");
+
+    static_assert(std::is_signed<IntTypeA>::value == std::is_signed<IntTypeB>::value,
+        "lcm() arguments must have the same signedness");
+
+    using CommonType = std::common_type_t<IntTypeA, IntTypeB>;
+
+    if (a == 0 && b == 0)
+        return CommonType{ 0 };
+
+    return static_cast<CommonType>(gul14::abs(a * b) / gcd(a, b));
+}
+
+} // namespace gul14
+
+#endif

--- a/include/gul14/gul.h
+++ b/include/gul14/gul.h
@@ -30,6 +30,7 @@
 // #include "gul14/date.h" not included by default to reduce compile times
 #include "gul14/escape.h"
 #include "gul14/finalizer.h"
+#include "gul14/gcd_lcm.h"
 #include "gul14/hexdump.h"
 #include "gul14/join_split.h"
 #include "gul14/num_util.h"

--- a/include/gul14/meson.build
+++ b/include/gul14/meson.build
@@ -6,6 +6,7 @@ standalone_headers = [
     'date.h',
     'escape.h',
     'finalizer.h',
+    'gcd_lcm.h',
     'hexdump.h',
     'join_split.h',
     'num_util.h',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -26,6 +26,7 @@ tests = [
     'test_cat.cc',
     'test_escape.cc',
     'test_finalizer.cc',
+    'test_gcd_lcm.cc',
     'test_hexdump.cc',
     'test_join_split.cc',
     'test_main.cc',

--- a/tests/test_gcd_lcm.cc
+++ b/tests/test_gcd_lcm.cc
@@ -1,0 +1,133 @@
+/**
+ * \file   test_gcd_lcm.cc
+ * \author \ref contributors
+ * \date   Created on August 5, 2022
+ * \brief  Test suite for gcd() and lcm().
+ *
+ * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <type_traits>
+
+#include "gul14/catch.h"
+#include "gul14/gcd_lcm.h"
+
+using gul14::gcd;
+using gul14::lcm;
+
+TEST_CASE("gcd(): Explicit test cases", "[gcd_lcm]")
+{
+    REQUIRE(gcd(2, 2) == 2);
+    REQUIRE(gcd(2, 3) == 1);
+    REQUIRE(gcd(3, 2) == 1);
+    REQUIRE(gcd(2, 4) == 2);
+    REQUIRE(gcd(4, 2) == 2);
+
+    REQUIRE(gcd(10, 15) == 5);
+    REQUIRE(gcd(15, 10) == 5);
+    REQUIRE(gcd(-10, 15) == 5);
+    REQUIRE(gcd(15, -10) == 5);
+
+    REQUIRE(gcd(42, 2) == 2);
+    REQUIRE(gcd(42, -2) == 2);
+    REQUIRE(gcd(-42, -2) == 2);
+    REQUIRE(gcd(-42, 2) == 2);
+
+    REQUIRE(gcd(9, 42) == 3);
+    REQUIRE(gcd(42, 9) == 3);
+    REQUIRE(gcd(-42, 9) == 3);
+    REQUIRE(gcd(-9, 42) == 3);
+
+    REQUIRE(gcd(4'000'000'020, 3'999'999'990) == 30);
+
+    REQUIRE(gcd(std::int16_t{ -256 }, std::int8_t{ -128 }) == std::int16_t{ 128 }); // Fails with GCC 9.3.0 std::gcd()
+    REQUIRE(gcd(-288LL, std::int8_t{ -128 }) == 32LL);
+
+    // Zeros
+    REQUIRE(gcd(0, 2) == 2);
+    REQUIRE(gcd(2, 0) == 2);
+    REQUIRE(gcd(0, 0) == 0);
+}
+
+TEST_CASE("gcd: Mixed types", "[gcd_lcm]")
+{
+    static_assert(std::is_same<decltype(gcd(42LL, 2)), long long>::value,
+        "gcd(long long, int) -> long long");
+    static_assert(std::is_same<decltype(gcd(42, 2LL)), long long>::value,
+        "gcd(int, long long) -> long long");
+    static_assert(std::is_same<decltype(gcd(42, std::int8_t{ 2 })), int>::value,
+        "gcd(int, int8_t) -> int");
+    static_assert(std::is_same<decltype(gcd(short{ 2 }, 42L)), long>::value,
+        "gcd(short, long) -> long");
+
+    static_assert(std::is_same<decltype(gcd(42ULL, 2U)), unsigned long long>::value,
+        "gcd(unsigned long long, unsigned int) -> unsigned long long");
+    static_assert(std::is_same<decltype(gcd(42U, 2ULL)), unsigned long long>::value,
+        "gcd(unsigned int, unsigned long long) -> unsigned long long");
+    static_assert(std::is_same<decltype(gcd(42U, std::uint8_t{ 2 })), unsigned int>::value,
+        "gcd(unsigned int, uint8_t) -> unsigned int");
+    static_assert(std::is_same<decltype(gcd(static_cast<unsigned short>(2), 42UL)), unsigned long>::value,
+        "gcd(unsigned short, unsigned long) -> unsigned long");
+}
+
+TEST_CASE("lcm(): Explicit test cases", "[gcd_lcm]")
+{
+    REQUIRE(lcm(1, 2) == 2);
+    REQUIRE(lcm(2, 1) == 2);
+    REQUIRE(lcm(2, 3) == 6);
+    REQUIRE(lcm(3, 2) == 6);
+    REQUIRE(lcm(2, 4) == 4);
+    REQUIRE(lcm(4, 2) == 4);
+
+    REQUIRE(lcm(10, 15) == 30);
+    REQUIRE(lcm(15, 10) == 30);
+    REQUIRE(lcm(-10, 15) == 30);
+    REQUIRE(lcm(15, -10) == 30);
+
+    REQUIRE(lcm(7, 5) == 35);
+    REQUIRE(lcm(-7, 5) == 35);
+    REQUIRE(lcm(7, -5) == 35);
+    REQUIRE(lcm(-7, -5) == 35);
+
+    REQUIRE(lcm(std::int16_t{ -256 }, std::int8_t{ -128 }) == std::int16_t{ 256 }); // Fails with GCC 9.3.0 std::lcm()
+    REQUIRE(lcm(-288LL, std::int8_t{ -128 }) == 1152LL);
+
+    // Zeros
+    REQUIRE(lcm(0, 2) == 0);
+    REQUIRE(lcm(2, 0) == 0);
+    REQUIRE(lcm(0, 0) == 0);
+}
+
+TEST_CASE("lcm: Mixed types", "[gcd_lcm]")
+{
+    static_assert(std::is_same<decltype(lcm(42LL, 2)), long long>::value,
+        "lcm(long long, int) -> long long");
+    static_assert(std::is_same<decltype(lcm(42, 2LL)), long long>::value,
+        "lcm(int, long long) -> long long");
+    static_assert(std::is_same<decltype(lcm(42, std::int8_t{ 2 })), int>::value,
+        "lcm(int, int8_t) -> int");
+    static_assert(std::is_same<decltype(lcm(short{ 2 }, 42L)), long>::value,
+        "lcm(short, long) -> long");
+
+    static_assert(std::is_same<decltype(lcm(42ULL, 2U)), unsigned long long>::value,
+        "lcm(unsigned long long, unsigned int) -> unsigned long long");
+    static_assert(std::is_same<decltype(lcm(42U, 2ULL)), unsigned long long>::value,
+        "lcm(unsigned int, unsigned long long) -> unsigned long long");
+    static_assert(std::is_same<decltype(lcm(42U, std::uint8_t{ 2 })), unsigned int>::value,
+        "lcm(unsigned int, uint8_t) -> unsigned int");
+    static_assert(std::is_same<decltype(lcm(static_cast<unsigned short>(2), 42UL)), unsigned long>::value,
+        "lcm(unsigned short, unsigned long) -> unsigned long");
+}

--- a/tests/test_gcd_lcm.cc
+++ b/tests/test_gcd_lcm.cc
@@ -102,6 +102,20 @@ TEST_CASE("lcm(): Explicit test cases", "[gcd_lcm]")
     REQUIRE(lcm(7, -5) == 35);
     REQUIRE(lcm(-7, -5) == 35);
 
+    REQUIRE(lcm(6, 10) == 30);
+    REQUIRE(lcm(60, 100) == 300);
+    REQUIRE(lcm(600, 1'000) == 3'000);
+    REQUIRE(lcm(6'000, 10'000) == 30'000);
+    REQUIRE(lcm(60'000, 100'000) == 300'000);
+
+    #if defined(INT64_MAX)
+    REQUIRE(lcm(60'000'000'000, 100'000'000'000) == 300'000'000'000);
+    REQUIRE(lcm(-60'000'000'000, 100'000'000'000) == 300'000'000'000);
+    REQUIRE(lcm(60'000'000'000, -100'000'000'000) == 300'000'000'000);
+    REQUIRE(lcm(-60'000'000'000, -100'000'000'000) == 300'000'000'000);
+    REQUIRE(lcm(60'000'000'000U, 100'000'000'000U) == 300'000'000'000U);
+    #endif
+
     REQUIRE(lcm(std::int16_t{ -256 }, std::int8_t{ -128 }) == std::int16_t{ 256 }); // Fails with GCC 9.3.0 std::lcm()
     REQUIRE(lcm(-288LL, std::int8_t{ -128 }) == 1152LL);
 

--- a/tests/test_gcd_lcm.cc
+++ b/tests/test_gcd_lcm.cc
@@ -106,7 +106,12 @@ TEST_CASE("lcm(): Explicit test cases", "[gcd_lcm]")
     REQUIRE(lcm(60, 100) == 300);
     REQUIRE(lcm(600, 1'000) == 3'000);
     REQUIRE(lcm(6'000, 10'000) == 30'000);
+
     REQUIRE(lcm(60'000, 100'000) == 300'000);
+    REQUIRE(lcm(-60'000, 100'000) == 300'000);
+    REQUIRE(lcm(60'000, -100'000) == 300'000);
+    REQUIRE(lcm(-60'000, -100'000) == 300'000);
+    REQUIRE(lcm(60'000U, 100'000U) == 300'000U);
 
     #if defined(INT64_MAX)
     REQUIRE(lcm(60'000'000'000, 100'000'000'000) == 300'000'000'000);


### PR DESCRIPTION
These functions can calculate the [greatest common divisor](https://en.wikipedia.org/wiki/Greatest_common_divisor) and [least common multiple](https://en.wikipedia.org/wiki/Least_common_multiple) of two integers.

They are very similar to the C++17 functions [std::gcd()](https://en.cppreference.com/w/cpp/numeric/gcd) and [std::lcm()](https://en.cppreference.com/w/cpp/numeric/lcm), but do not work with integers of different signedness – a static_assert prevents that. This makes them safer to use because the standard versions cause UB when used with one unsigned integer and one negative integer.