### PR TITLE
Add rudimentary Github CI configuration

### DIFF
--- a/.github/workflows/build-and-run-tests-posix.yml
+++ b/.github/workflows/build-and-run-tests-posix.yml
@@ -1,0 +1,48 @@
+name: Build and run tests on Linux and MacOS platforms
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+
+jobs:
+  build-and-run-tests-posix:
+    runs-on: ${{ inputs.platform }}
+    steps:
+    - run: echo "Job triggered by ${{ github.event_name }} event, running on ${{ runner.os }}."
+    - run: echo "Branch ${{ github.ref }} on repository ${{ github.repository }}"
+
+    - name: Check out repository code
+      uses: actions/checkout@v3
+
+    - name: Install Ninja
+      run: sudo apt-get install ninja-build
+
+    - name: Retrieve Meson from cache
+      id: cache-meson
+      uses: actions/cache@v3
+      with:
+        path: meson-0.63.0
+        key: meson-0.63.0
+
+    - name: Download Meson
+      if: steps.cache-meson.outputs.cache-hit != 'true'
+      run: wget -q https://github.com/mesonbuild/meson/releases/download/0.63.0/meson-0.63.0.tar.gz &&
+           tar -xzf meson-0.63.0.tar.gz &&
+           rm meson-0.63.0.tar.gz
+
+    - name: Create symbolic link for Meson
+      run: ln -s meson-0.63.0/meson.py . &&
+           ls -la
+
+    - name: Configure build directories
+      run: ./meson.py --buildtype=release build.release &&
+           ./meson.py --buildtype=debug build.asan -Db_sanitize=address
+
+    - name: Build and run ASAN tests
+      run: ./meson.py test -C build.asan
+
+    - name: Build and run release tests
+      run: ./meson.py test -C build.release

--- a/.github/workflows/build-and-run-tests-posix.yml
+++ b/.github/workflows/build-and-run-tests-posix.yml
@@ -18,7 +18,12 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Ninja
-      run: sudo apt-get install ninja-build
+      run: |
+        if [[ "${{ inputs.platform }}" == Linux ]]; then
+          sudo apt-get install ninja-build
+        else
+          brew install ninja
+        fi
 
     - name: Retrieve Meson from cache
       id: cache-meson

--- a/.github/workflows/build-and-run-tests-posix.yml
+++ b/.github/workflows/build-and-run-tests-posix.yml
@@ -19,11 +19,15 @@ jobs:
 
     - name: Install Ninja
       run: |
-        if [[ "${{ inputs.platform }}" == Linux ]]; then
+        if [[ "${{ inputs.platform }}" == ubuntu-latest ]]; then
           sudo apt-get install ninja-build
-        else
+        elif [[ "${{ inputs.platform }}" == macos-latest ]]; then
           brew install ninja
+        else
+          echo Do not know how to install Ninja on platform ${{ inputs.platform }}
+          false
         fi
+      shell: bash
 
     - name: Retrieve Meson from cache
       id: cache-meson
@@ -51,3 +55,11 @@ jobs:
 
     - name: Build and run release tests
       run: ./meson.py test -C build.release
+
+    - uses: actions/upload-artifact@v3
+      if: ${{ always() }}
+      with:
+        name: build-dirs-${{ inputs.platform }}
+        path: |
+          build.release/
+          build.asan/

--- a/.github/workflows/build-and-run-tests-posix.yml
+++ b/.github/workflows/build-and-run-tests-posix.yml
@@ -38,17 +38,20 @@ jobs:
 
     - name: Download Meson
       if: steps.cache-meson.outputs.cache-hit != 'true'
-      run: wget -q https://github.com/mesonbuild/meson/releases/download/0.63.0/meson-0.63.0.tar.gz &&
-           tar -xzf meson-0.63.0.tar.gz &&
-           rm meson-0.63.0.tar.gz
+      run: |
+        wget -q https://github.com/mesonbuild/meson/releases/download/0.63.0/meson-0.63.0.tar.gz
+        tar -xzf meson-0.63.0.tar.gz
+        rm meson-0.63.0.tar.gz
 
     - name: Create symbolic link for Meson
-      run: ln -s meson-0.63.0/meson.py . &&
-           ls -la
+      run: |
+        ln -s meson-0.63.0/meson.py .
+        ls -la
 
     - name: Configure build directories
-      run: ./meson.py --buildtype=release build.release &&
-           ./meson.py --buildtype=debug build.asan -Db_sanitize=address
+      run: |
+        ./meson.py --buildtype=release build.release
+        ./meson.py --buildtype=debug build.asan -Db_sanitize=address
 
     - name: Build and run ASAN tests
       run: ./meson.py test -C build.asan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI for GUL14
+
+on: [push]
+
+jobs:
+  build-and-run-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "Job triggered by ${{ github.event_name }} event, running on ${{ runner.os }}."
+    - run: echo "Branch ${{ github.ref }} on repository ${{ github.repository }}"
+    - name: Check out repository code
+      uses: actions/checkout@v3
+    - name: Install Ninja
+      run: sudo apt-get install ninja-build
+    - name: Download Meson
+      run: wget -q https://github.com/mesonbuild/meson/releases/download/0.63.0/meson-0.63.0.tar.gz &&
+           tar -xzf meson-0.63.0.tar.gz &&
+           rm meson-0.63.0.tar.gz &&
+           ln -s meson-0.63.0/meson.py . &&
+           ls -la
+    - name: Configure build directories
+      run: ./meson.py --buildtype=release build.release &&
+           ./meson.py --buildtype=debug build.asan -Db_sanitize=address
+    - name: Build and run ASAN tests
+      run: ./meson.py test -C build.asan
+    - name: Build and run release tests
+      run: ./meson.py test -C build.release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,36 @@ jobs:
     steps:
     - run: echo "Job triggered by ${{ github.event_name }} event, running on ${{ runner.os }}."
     - run: echo "Branch ${{ github.ref }} on repository ${{ github.repository }}"
+
     - name: Check out repository code
       uses: actions/checkout@v3
+
     - name: Install Ninja
       run: sudo apt-get install ninja-build
+
+    - name: Retrieve Meson from cache
+      id: cache-meson
+      uses: actions/cache@v3
+      with:
+        path: meson-0.63.0
+        key: ${{ runner.os }}-meson-0.63.0
+
     - name: Download Meson
+      if: steps.cache-meson.outputs.cache-hit != 'true'
       run: wget -q https://github.com/mesonbuild/meson/releases/download/0.63.0/meson-0.63.0.tar.gz &&
            tar -xzf meson-0.63.0.tar.gz &&
-           rm meson-0.63.0.tar.gz &&
-           ln -s meson-0.63.0/meson.py . &&
+           rm meson-0.63.0.tar.gz
+
+    - name: Create symbolic link for Meson
+      run: ln -s meson-0.63.0/meson.py . &&
            ls -la
+
     - name: Configure build directories
       run: ./meson.py --buildtype=release build.release &&
            ./meson.py --buildtype=debug build.asan -Db_sanitize=address
+
     - name: Build and run ASAN tests
       run: ./meson.py test -C build.asan
+
     - name: Build and run release tests
       run: ./meson.py test -C build.release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,43 +1,15 @@
 name: CI for GUL14
 
-on: [push]
+on:
+  push
 
 jobs:
-  build-and-run-tests:
-    runs-on: ubuntu-latest
-    steps:
-    - run: echo "Job triggered by ${{ github.event_name }} event, running on ${{ runner.os }}."
-    - run: echo "Branch ${{ github.ref }} on repository ${{ github.repository }}"
+  build-and-run-tests-on-ubuntu:
+    uses: ./.github/workflows/build-and-run-tests-posix.yml
+    with:
+      platform: ubuntu-latest
 
-    - name: Check out repository code
-      uses: actions/checkout@v3
-
-    - name: Install Ninja
-      run: sudo apt-get install ninja-build
-
-    - name: Retrieve Meson from cache
-      id: cache-meson
-      uses: actions/cache@v3
-      with:
-        path: meson-0.63.0
-        key: ${{ runner.os }}-meson-0.63.0
-
-    - name: Download Meson
-      if: steps.cache-meson.outputs.cache-hit != 'true'
-      run: wget -q https://github.com/mesonbuild/meson/releases/download/0.63.0/meson-0.63.0.tar.gz &&
-           tar -xzf meson-0.63.0.tar.gz &&
-           rm meson-0.63.0.tar.gz
-
-    - name: Create symbolic link for Meson
-      run: ln -s meson-0.63.0/meson.py . &&
-           ls -la
-
-    - name: Configure build directories
-      run: ./meson.py --buildtype=release build.release &&
-           ./meson.py --buildtype=debug build.asan -Db_sanitize=address
-
-    - name: Build and run ASAN tests
-      run: ./meson.py test -C build.asan
-
-    - name: Build and run release tests
-      run: ./meson.py test -C build.release
+  build-and-run-tests-on-macos:
+    uses: ./.github/workflows/build-and-run-tests-posix.yml
+    with:
+      platform: macos-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 ._*
 nbproject
-build*
+build*/
 .vs
 !.vs/launch.vs.json
 !.vs/tasks.vs.json


### PR DESCRIPTION
This adds a rudimentary GitHub workflow for building GUL14 on Ubuntu. Both a debug build with address sanitizer and a release build are created and their test suites are run.