### PR TITLE
Fix Trigger wait tests

### DIFF
--- a/include/gul14/Trigger.h
+++ b/include/gul14/Trigger.h
@@ -4,7 +4,7 @@
  * \date    Created on September 21, 2018
  * \brief   Declaration of the Trigger class for the General Utility Library.
  *
- * \copyright Copyright 2018-2020 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -163,15 +163,15 @@ public:
     void wait() const;
 
     /**
-     * Suspend execution of the current thread until the trigger goes high (true) or the
-     * given time span has passed.
+     * Suspend execution of the current thread until the trigger goes high (true) or at
+     * least the given time span has passed.
      * Execution is also resumed if the object is destructed.
      *
      * \tparam Clock  The type of the underlying clock, e.g. std::chrono::system_clock.
      * \tparam Duration  The duration type to be used, typically Clock::duration.
      *
      * \param delta_t  A time span to wait. If the trigger still has not become true after
-     *                 this time, the function returns false.
+     *                 (at least) this time, the function returns false.
      *
      * \returns the state of the trigger at the end of the call. If this is false, the
      *          function has exited due to timeout.
@@ -188,7 +188,7 @@ public:
 
     /**
      * Suspend execution of the current thread until the trigger goes high (true) or the
-     * given time point has been reached.
+     * given time point has been passed.
      * Execution is also resumed if the object is destructed.
      *
      * \tparam Clock  The type of the underlying clock, e.g. std::chrono::system_clock.

--- a/include/gul14/Trigger.h
+++ b/include/gul14/Trigger.h
@@ -142,7 +142,7 @@ public:
      * Setting it to true will cause any waiting threads to resume.
      */
     GUL_EXPORT
-    Trigger &operator=(bool interrupt) noexcept;
+    Trigger& operator=(bool interrupt) noexcept;
 
     /// Set the trigger to low (false).
     GUL_EXPORT
@@ -180,7 +180,7 @@ public:
      * For many applications, the free function sleep() is easier to use.
      */
     template <class Rep, class Period>
-    bool wait_for(const std::chrono::duration<Rep, Period> &delta_t) const
+    bool wait_for(const std::chrono::duration<Rep, Period>& delta_t) const
     {
         std::unique_lock<std::mutex> lock(mutex_);
         return cv_.wait_for(lock, delta_t, [this]{ return triggered_; });
@@ -203,7 +203,7 @@ public:
      * For many applications, the free function sleep() is easier to use.
      */
     template <class Clock, class Duration>
-    bool wait_until(const std::chrono::time_point<Clock, Duration> &t) const
+    bool wait_until(const std::chrono::time_point<Clock, Duration>& t) const
     {
         std::unique_lock<std::mutex> lock(mutex_);
         return cv_.wait_until(lock, t, [this]{ return triggered_; });

--- a/tests/test_Trigger.cc
+++ b/tests/test_Trigger.cc
@@ -4,7 +4,7 @@
  * \date   Created on September 21, 2018
  * \brief  Test suite for the Trigger class from the General Utility Library.
  *
- * \copyright Copyright 2018 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -36,7 +36,6 @@ using gul14::Trigger;
 namespace {
 
 constexpr int MS_BEFORE = 1;
-constexpr int MS_AFTER = 18;
 
 } // anonymous namespace
 
@@ -51,12 +50,11 @@ TEST_CASE("Construction, assignment, equality and bool operator work", "[Trigger
     REQUIRE(trg2 == true);
     trg2 = false;
     REQUIRE(trg2 == false);
-
 }
 
 SCENARIO("Trigger::wait*() resumes if another thread calls trigger()", "[Trigger]")
 {
-    GIVEN("a trigger and a helper thread that sets it to true after 30 ms")
+    GIVEN("a trigger and a helper thread that sets it to true after 50 ms")
     {
         Trigger trg;
         std::chrono::steady_clock::time_point t0;
@@ -74,10 +72,9 @@ SCENARIO("Trigger::wait*() resumes if another thread calls trigger()", "[Trigger
             trg.wait();
             auto time_ms = toc<std::chrono::milliseconds>(t0);
 
-            THEN("it resumes after approximately 50 ms")
+            THEN("it resumes after >= 50 ms")
             {
                 REQUIRE(time_ms >= 50 - MS_BEFORE);
-                REQUIRE(time_ms <= 50 + MS_AFTER);
             }
         }
 
@@ -86,28 +83,28 @@ SCENARIO("Trigger::wait*() resumes if another thread calls trigger()", "[Trigger
             trg.wait_for(1s);
             auto time_ms = toc<std::chrono::milliseconds>(t0);
 
-            THEN("it resumes after approximately 50 ms")
+            THEN("it resumes after >= 50 ms")
             {
                 REQUIRE(time_ms >= 50 - MS_BEFORE);
-                REQUIRE(time_ms <= 50 + MS_AFTER);
             }
         }
 
-        WHEN("the main thread calls wait_until(now + 1s)")
+        WHEN("the main thread calls wait_until(now + 5s)")
         {
-            trg.wait_until(std::chrono::system_clock::now() + 1s);
+            trg.wait_until(std::chrono::system_clock::now() + 5s);
             auto time_ms = toc<std::chrono::milliseconds>(t0);
 
-            THEN("it resumes after approximately 50 ms")
+            THEN("it resumes after >= 50 ms, but before 5 s")
             {
                 REQUIRE(time_ms >= 50 - MS_BEFORE);
-                REQUIRE(time_ms <= 50 + MS_AFTER);
+                REQUIRE(time_ms <= 5000);
             }
         }
     }
 }
 
-SCENARIO("Trigger::wait_for() and wait_until() wait the requested amount of time", "[Trigger]")
+SCENARIO("Trigger::wait_for() and wait_until() wait at least the requested amount of time",
+         "[Trigger]")
 {
     Trigger trg;
 
@@ -118,10 +115,9 @@ SCENARIO("Trigger::wait_for() and wait_until() wait the requested amount of time
         trg.wait_for(50ms);
         auto time_ms = toc<std::chrono::milliseconds>(t0);
 
-        THEN("execution resumes after approximately 50 ms")
+        THEN("execution resumes after >= 50 ms")
         {
             REQUIRE(time_ms >= 50 - MS_BEFORE);
-            REQUIRE(time_ms <= 50 + MS_AFTER);
         }
     }
 
@@ -130,10 +126,9 @@ SCENARIO("Trigger::wait_for() and wait_until() wait the requested amount of time
         trg.wait_until(std::chrono::system_clock::now() + 50ms);
         auto time_ms = toc<std::chrono::milliseconds>(t0);
 
-        THEN("execution resumes after approximately 50 ms")
+        THEN("execution resumes after >= 50 ms")
         {
             REQUIRE(time_ms >= 50 - MS_BEFORE);
-            REQUIRE(time_ms <= 50 + MS_AFTER);
         }
     }
 }

--- a/tests/test_Trigger.cc
+++ b/tests/test_Trigger.cc
@@ -33,12 +33,6 @@ using gul14::toc;
 using gul14::sleep;
 using gul14::Trigger;
 
-namespace {
-
-constexpr int MS_BEFORE = 1;
-
-} // anonymous namespace
-
 TEST_CASE("Construction, assignment, equality and bool operator work", "[Trigger]")
 {
     Trigger trg;
@@ -74,7 +68,7 @@ SCENARIO("Trigger::wait*() resumes if another thread calls trigger()", "[Trigger
 
             THEN("it resumes after >= 50 ms")
             {
-                REQUIRE(time_ms >= 50 - MS_BEFORE);
+                REQUIRE(time_ms >= 50);
             }
         }
 
@@ -85,7 +79,7 @@ SCENARIO("Trigger::wait*() resumes if another thread calls trigger()", "[Trigger
 
             THEN("it resumes after >= 50 ms")
             {
-                REQUIRE(time_ms >= 50 - MS_BEFORE);
+                REQUIRE(time_ms >= 50);
             }
         }
 
@@ -96,7 +90,7 @@ SCENARIO("Trigger::wait*() resumes if another thread calls trigger()", "[Trigger
 
             THEN("it resumes after >= 50 ms, but before 5 s")
             {
-                REQUIRE(time_ms >= 50 - MS_BEFORE);
+                REQUIRE(time_ms >= 50);
                 REQUIRE(time_ms <= 5000);
             }
         }
@@ -117,7 +111,7 @@ SCENARIO("Trigger::wait_for() and wait_until() wait at least the requested amoun
 
         THEN("execution resumes after >= 50 ms")
         {
-            REQUIRE(time_ms >= 50 - MS_BEFORE);
+            REQUIRE(time_ms >= 50);
         }
     }
 
@@ -128,7 +122,7 @@ SCENARIO("Trigger::wait_for() and wait_until() wait at least the requested amoun
 
         THEN("execution resumes after >= 50 ms")
         {
-            REQUIRE(time_ms >= 50 - MS_BEFORE);
+            REQUIRE(time_ms >= 50);
         }
     }
 }


### PR DESCRIPTION
This PR removes several "not-later-than" tests for Trigger::wait_for() and Trigger::wait_until().
    
Many Trigger-related tests fail on GitHub MacOS runners because the systems are under heavy contention. This sometimes leads to delays on the order of several tens of milliseconds, which is outside of the tolerance of the old delay tests.
    
Strictly speaking, there is no guarantee that Trigger's wait* functions wake up after any particular time span at all, so we should not test for that.

Drive-by-corrections include documentation and whitespace. :)