### PR TITLE
num_util: within_orders() detects 0.0 == 0.0

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -143,6 +143,11 @@ namespace gul14 {
  *
  * \section changelog_2_x 2.x Versions
  *
+ * \subsection v2_7_1 Version 2.7.1
+ *
+ * - *Released with DOOCS 22.10.0*
+ * - within_orders(0.0, 0.0, 10) results now in true
+ *
  * \subsection v2_7 Version 2.7
  *
  * - Add repeat()

--- a/include/gul14/gcd_lcm.h
+++ b/include/gul14/gcd_lcm.h
@@ -57,7 +57,7 @@ namespace gul14 {
  * auto static_assertion_failure = gul14::gcd(10u, -5);
  * \endcode
  *
- * \since GUL 2.7
+ * \since GUL version 2.7
  */
 template <typename IntTypeA, typename IntTypeB>
 constexpr inline auto
@@ -111,7 +111,7 @@ gcd(IntTypeA a, IntTypeB b)
  * auto static_assertion_failure = gul14::lcm(10u, -5);
  * \endcode
  *
- * \since GUL 2.7
+ * \since GUL version 2.7
  */
 template <typename IntTypeA, typename IntTypeB>
 constexpr inline auto

--- a/include/gul14/num_util.h
+++ b/include/gul14/num_util.h
@@ -71,16 +71,17 @@ constexpr auto abs(ValueT n) noexcept -> std::enable_if_t<not std::is_unsigned<V
  * orders equals digits does not hold so strict anymore.
  *
  * Remember that any nonzero number has infinite different significant digits compared
- * with 0.00000000. So if either a or b is 0.0 the result must be false.
+ * with 0.00000000. So if one operand is 0.0 while the other is not 0.0 the result must be false.
  *
  * \param a       The first number to compare
- * \param b       The second number to compare (same type as a)
+ * \param b       The second number to compare (same type as \c a)
  * \param orders  The number of digits to take for comparison (any numeric type)
  *
- * \returns true if the difference between a and b is orders of magnitude lower than the
- *          value of a or b.
+ * \returns true if \c a and \c b are equal or the difference between \c a and \c b is
+ *          \c orders orders of magnitude lower than the value of \c a or \c b
  *
  * \since GUL version 1.4 parameter type \b NumT can be an integral type (had to be floating point before)
+ * \since GUL version 2.7.1 return true if a == b == 0.0
  */
 template<typename NumT, typename OrderT,
     typename = std::enable_if_t<
@@ -89,8 +90,12 @@ template<typename NumT, typename OrderT,
     >>
 bool within_orders(const NumT a, const NumT b, const OrderT orders) noexcept(false) {
     // std::pow() is not noexcept, which might or might not be true
-    return gul14::abs(a - b)
-        < (std::max(gul14::abs(a), gul14::abs(b)) / std::pow(static_cast<std::decay_t<NumT>>(10.0), orders));
+    auto difference = gul14::abs(a - b);
+    if (difference == NumT{ 0 })
+        return true;
+    auto maximum = std::max(gul14::abs(a), gul14::abs(b));
+    auto limit = maximum / std::pow(static_cast<std::decay_t<NumT>>(10.0), orders);
+    return difference < limit;
 }
 
 /**

--- a/tests/test_num_util.cc
+++ b/tests/test_num_util.cc
@@ -146,6 +146,11 @@ TEST_CASE("test within_orders()", "[num_util]")
     REQUIRE(gul14::within_orders(1.0, 0.0, 1) == false);
     REQUIRE(gul14::within_orders(1.0, 0.0, 0) == false);
 
+    // Compare zero with zero
+    double a = 0.0;
+    REQUIRE(gul14::within_orders<double>(a, a, 5) == true);
+    REQUIRE(gul14::within_orders(static_cast<float>(a), 0.0f, 5) == true);
+
     // From the Doxygen example with integers
     REQUIRE(gul14::within_orders(23736384, 23736228, 5) == true);
     REQUIRE(gul14::within_orders(23736384, 23735384, 5) == false);


### PR DESCRIPTION
**[why]**
`gul14::within_orders(0.0, 0.0, 5)` is `false`. Instinctively one might expect it to be true, as both inputs are strictly equal.

**[how]**
Check for equality first, then additionally add some lenience.

Fixes: #17