### PR TITLE
rpm: Add workaround for the meson issue

### DIFF
--- a/libgul14.spec
+++ b/libgul14.spec
@@ -35,6 +35,10 @@ Source0:        gul14-%{version}.tar.xz
 
 %if 0%{?rhel} < 8
 BuildRequires:  devtoolset-7-gcc-c++
+# This is needed to fix an issue with the currently meson
+# package, it might be obsolete as soon as a new meson
+# package is rolled out.
+BuildRequires:  epel-rpm-macros
 %endif
 BuildRequires:  gcc-c++
 BuildRequires:  meson

--- a/libgul14.spec
+++ b/libgul14.spec
@@ -25,7 +25,7 @@
 #
 
 Name:           libgul14
-Version:        2.6
+Version:        2.7
 Release:        1%{?dist}
 Summary:        General Utility Library
 
@@ -99,5 +99,8 @@ Requires:       %{name}-devel%{?_isa} = %{version}-%{release}
 %{_libdir}/%{name}.a
 
 %changelog
+* Thu Oct 13 2022 Soeren Grunewald <soeren.grunewald@desy.de> - 2.7-1
+- New upstream release
+
 * Thu Aug 19 2021 Soeren Grunewald <soeren.grunewald@desy.de> - 2.6-1
 - Initial release


### PR DESCRIPTION
On a standard RHEL7 installation we can not build rpm's unless we have an extra macro installed.

The upstream meson package for RHEL7 [might add this dependency](https://bugzilla.redhat.com/show_bug.cgi?id=2101564), but this may take some time and we may do not wanna wait for it, so we can fix it one our own.