### PR TITLE
SmallVector: Fix compiler warning

### DIFF
--- a/include/gul14/SmallVector.h
+++ b/include/gul14/SmallVector.h
@@ -803,6 +803,8 @@ public:
     Iterator insert(ConstIterator pos, SizeType num_elements, const ValueType& value)
     {
         const auto idx = static_cast<SizeType>(pos - begin());
+        if (num_elements < 1)
+            return begin() + idx;
 
         const SizeType num_assignable = make_space_at_idx_for_n_elements(idx, num_elements);
         Iterator insert_pos = begin() + idx;
@@ -843,6 +845,8 @@ public:
     {
         const auto idx = static_cast<SizeType>(pos - begin());
         const auto num_elements = static_cast<SizeType>(std::distance(first, last));
+        if (num_elements < 1)
+            return begin() + idx;
 
         const SizeType num_assignable = make_space_at_idx_for_n_elements(idx, num_elements);
         Iterator insert_pos = begin() + idx;


### PR DESCRIPTION
**[why]**
When compiled with `-O3` (aka Meson option `optimization=3`) GCC 12.2 optimizes too good:
```
In file included from /usr/include/c++/12/algorithm:60,
                 from ../tests/test_SmallVector.cc:23:
In static member function ‘static _Tp* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(const _Tp*, const _Tp*, _Tp*) [with _Tp = int; bool _IsMove = false]’,
    inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = const int*; _OI = int*]’ at /usr/include/c++/12/bits/stl_algobase.h:495:30,
    inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = const int*; _OI = int*]’ at /usr/include/c++/12/bits/stl_algobase.h:522:42,
    inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = const int*; _OI = int*]’ at /usr/include/c++/12/bits/stl_algobase.h:529:31,
    inlined from ‘_OI std::copy(_II, _II, _OI) [with _II = const int*; _OI = int*]’ at /usr/include/c++/12/bits/stl_algobase.h:620:7,
    inlined from ‘_OutputIterator std::__copy_n(_RandomAccessIterator, _Size, _OutputIterator, random_access_iterator_tag) [with _RandomAccessIterator = const int*; _Size = unsigned int; _OutputIterator = int*]’ at /usr/include/c++/12/bits/stl_algo.h:728:23,
    inlined from ‘_OIter std::copy_n(_IIter, _Size, _OIter) [with _IIter = const int*; _Size = unsigned int; _OIter = int*]’ at /usr/include/c++/12/bits/stl_algo.h:760:27,
    inlined from ‘gul14::SmallVector<ElementT, in_capacity>::ValueType* gul14::SmallVector<ElementT, in_capacity>::insert(ConstIterator, InputIterator, InputIterator) [with InputIterator = const int*; <template-parameter-2-2> = void; ElementT = int; long unsigned int in_capacity = 10]’ at ../include/gul14/SmallVector.h:851:20,
    inlined from ‘gul14::SmallVector<ElementT, in_capacity>::ValueType* gul14::SmallVector<ElementT, in_capacity>::insert(ConstIterator, std::initializer_list<_Tp>) [with ElementT = int; long unsigned int in_capacity = 10]’ at ../include/gul14/SmallVector.h:876:22,
    inlined from ‘void ____C_A_T_C_H____T_E_S_T____90()’ at ../tests/test_SmallVector.cc:1278:20:
/usr/include/c++/12/bits/stl_algobase.h:431:30: warning: argument 2 null where non-null expected [-Wnonnull]
  431 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/12/bits/stl_algobase.h:431:30: note: in a call to built-in function ‘void* __builtin_memmove(void*, const void*, long unsigned int)’
```

**[how]**
This is the case when we add zero elements from some iterator-like source. We pass that two iterators on unchecked and finally want to memmove the elements but there are none.

Now we just check if there is something to actually insert and bail out if not.

Fixes: #22