### PR TITLE
Feature/more warnings

### DIFF
--- a/include/gul14/case_ascii.h
+++ b/include/gul14/case_ascii.h
@@ -41,9 +41,8 @@ namespace gul14 {
 constexpr char lowercase_ascii(char c) noexcept
 {
     if (c >= 'A' && c <= 'Z')
-        return c - 'A' + 'a';
-    else
-        return c;
+        c = static_cast<char>(c + ('a' - 'A'));
+    return c;
 }
 
 /**
@@ -81,9 +80,8 @@ std::string &lowercase_ascii_inplace(std::string &str) noexcept;
 constexpr char uppercase_ascii(char c) noexcept
 {
     if (c >= 'a' && c <= 'z')
-        return c - 'a' + 'A';
-    else
-        return c;
+        c = static_cast<char>(c - ('a' - 'A'));
+    return c;
 }
 
 /**

--- a/src/meson.build
+++ b/src/meson.build
@@ -92,6 +92,9 @@ add_cpp_args = [
 if meson.get_compiler('cpp').has_argument('-Wshadow') # msvc doesnt have
     add_cpp_args += [ '-Wshadow' ]
 endif
+if meson.get_compiler('cpp').has_argument('-Wconversion') # msvc doesnt have
+    add_cpp_args += [ '-Wconversion' ]
+endif
 
 libgul = both_libraries(
     meson.project_name(), libgul_src + [ version_cc ],


### PR DESCRIPTION
As pointed out by Jason Tuner in CppWeekly #347, a Sony PlayStation
Jailbreak would probably not have happened, if the developers had
enable and respected compiler warnings.

See https://mcs-gitlab.desy.de/doocs/doocs-core-libraries/clientlib/-/merge_requests/62