### PR TITLE
Silence a few -Wconversion warnings

### DIFF
--- a/include/gul14/statistics.h
+++ b/include/gul14/statistics.h
@@ -558,7 +558,7 @@ auto standard_deviation(ContainerT const& container, Accessor accessor = Element
     auto sum = std::accumulate(container.cbegin(), container.cend(),
         ResultT{ },
         [mean_val, accessor] (ResultT const& accu, ElementT const& el)
-        { return accu + std::pow(accessor(el) - mean_val, 2); });
+        { return accu + std::pow(static_cast<ResultT>(accessor(el)) - mean_val, 2); });
 
     sum /= static_cast<ResultT>(container.size() - 1);
 

--- a/tests/test_SmallVector.cc
+++ b/tests/test_SmallVector.cc
@@ -1191,7 +1191,8 @@ TEST_CASE("SmallVector: insert(ConstIterator, SizeType, const ValueType &)", "[S
     for (int n = 0; n != 50; ++n)
     {
         int num_elements = dist(gen) % 10;
-        int insert_idx = (vec.size() == 0) ? 0 : (dist(gen) % vec.size());
+        int insert_idx =
+            (vec.size() == 0) ? 0 : (dist(gen) % static_cast<int>(vec.size()));
         int value = dist(gen) % 100;
 
         vec.insert(vec.begin() + insert_idx, num_elements, value);
@@ -1245,7 +1246,8 @@ TEST_CASE("SmallVector: insert(ConstIterator, InputIterator, InputIterator)", "[
     for (int n = 0; n != 50; ++n)
     {
         int num_elements = dist(gen) % 10;
-        int insert_idx = (vec.size() == 0) ? 0 : (dist(gen) % vec.size());
+        int insert_idx =
+            (vec.size() == 0) ? 0 : (dist(gen) % static_cast<int>(vec.size()));
 
         std::vector<int> new_elements(num_elements);
         std::generate(new_elements.begin(), new_elements.end(), [&]() { return dist(gen) % 100; });


### PR DESCRIPTION
This PR silences the last batch of warnings. After this commit, GUL14 compiles cleanly with -Wshadow -Wconversion (at least on GCC).