### PR TITLE
Move in_place_t and in_place into a new utility.h header

### DIFF
--- a/include/gul14/expected.h
+++ b/include/gul14/expected.h
@@ -31,6 +31,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "gul14/utility.h"
+
 namespace gul14 {
 
 /**
@@ -137,12 +139,6 @@ struct is_trivially_copy_constructible<std::vector<T, A>> : std::false_type {};
 template <class T, class E> class expected;
 
 class monostate {};
-
-struct in_place_t {
-  explicit in_place_t() = default;
-};
-
-static constexpr in_place_t in_place{};
 
 template <class E>
 class unexpected

--- a/include/gul14/meson.build
+++ b/include/gul14/meson.build
@@ -25,6 +25,7 @@ standalone_headers = [
     'Trigger.h',
     'trim.h',
     'type_name.h',
+    'utility.h',
 ]
 
 libgul_sub_headers = files(standalone_headers)

--- a/include/gul14/optional.h
+++ b/include/gul14/optional.h
@@ -34,7 +34,9 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+
 #include "gul14/internal.h"
+#include "gul14/utility.h"
 
 /// \cond HIDE_SYMBOLS
 #define GUL_OPTIONAL_REQUIRES(...) typename std::enable_if<__VA_ARGS__::value, bool>::type = false
@@ -131,12 +133,6 @@ void adl_swap(T& t, T& u) noexcept(noexcept(swap(t, u))) {
 
 constexpr struct trivial_init_t {
 } trivial_init{};
-
-
-// 20.5.6, In-place construction
-
-constexpr struct in_place_t {
-} in_place{};
 
 
 // 20.5.7, Disengaged state indicator

--- a/include/gul14/utility.h
+++ b/include/gul14/utility.h
@@ -1,0 +1,42 @@
+/**
+ * \file    utility.h
+ * \authors \ref contributors
+ * \brief   Declaration of the in_place_t type and of the in_place constant.
+ * \date    Created on March 31, 2023
+ *
+ * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef GUL14_UTILITY_H_
+#define GUL14_UTILITY_H_
+
+namespace gul14 {
+
+/// A type for constructor disambiguation, used by gul14::expected and gul14::optional.
+struct in_place_t
+{
+    explicit in_place_t() = default;
+};
+
+/**
+ * A tag that can be passed to the constructors of gul14::expected and gul14::optional
+ * to request in-place construction.
+ */
+static constexpr in_place_t in_place{};
+
+} // namespace gul14
+
+#endif

--- a/tests/test_expected.cc
+++ b/tests/test_expected.cc
@@ -25,6 +25,7 @@
 
 #include "gul14/catch.h"
 #include "gul14/expected.h"
+#include "gul14/optional.h" // to check if there are clashing declarations, e.g. in_place_t
 
 using namespace std::literals;
 


### PR DESCRIPTION
Unfortunately the last 2.8.0 release is broken. This is the corresponding bugfix. I would retroactively re-tag the fixed version as 2.8.0 unless someone prefers a 2.8.1 release.

[why]
Both optional.h and expected.h provided conflicting declarations of this type/constant. This lead to a compilation error if both headers were included.

[how]
Remove the declarations from optional.h and expected.h and put them into a new utility.h header instead.