### PR TITLE
Bugfix for gul14::visit()

### DIFF
--- a/include/gul14/variant.h
+++ b/include/gul14/variant.h
@@ -349,7 +349,6 @@ using is_nothrow_swappable =
 } // namespace detail_variant
 
 #define AUTO_REFREF_RETURN(...) { return __VA_ARGS__; }
-#define DECLTYPE_AUTO_RETURN(...) { return __VA_ARGS__; }
 
 [[noreturn]] inline void throw_bad_variant_access() {
     throw bad_variant_access{};
@@ -852,26 +851,31 @@ using is_nothrow_swappable =
         inline static constexpr decltype(auto) visit_alt(Visitor &&visitor,
                                                         Vs &&... vs)
 #ifdef GUL14_VARIANT_SWITCH_VISIT
-          DECLTYPE_AUTO_RETURN(
-              base::dispatcher<
+        {
+          return base::dispatcher<
                   true,
                   base::dispatch_result_t<Visitor,
                                           decltype(as_base(
                                               std::forward<Vs>(vs)))...>>::
                   template dispatch<0>(std::forward<Visitor>(visitor),
-                                       as_base(std::forward<Vs>(vs))...))
+                                       as_base(std::forward<Vs>(vs))...);
+        }
 #elif !defined(_MSC_VER) || _MSC_VER >= 1910
-          DECLTYPE_AUTO_RETURN(base::at(
+        {
+          return base::at(
               fmatrix<Visitor &&,
                       decltype(as_base(std::forward<Vs>(vs)))...>::value,
               vs.index()...)(std::forward<Visitor>(visitor),
-                             as_base(std::forward<Vs>(vs))...))
+                             as_base(std::forward<Vs>(vs))...);
+        }
 #else
-          DECLTYPE_AUTO_RETURN(base::at(
+        {
+          return base::at(
               base::make_fmatrix<Visitor &&,
                       decltype(as_base(std::forward<Vs>(vs)))...>(),
               vs.index()...)(std::forward<Visitor>(visitor),
-                             as_base(std::forward<Vs>(vs))...))
+                             as_base(std::forward<Vs>(vs))...);
+        }
 #endif
 
         template <typename Visitor, typename... Vs>
@@ -879,27 +883,32 @@ using is_nothrow_swappable =
                                                            Visitor &&visitor,
                                                            Vs &&... vs)
 #ifdef GUL14_VARIANT_SWITCH_VISIT
-          DECLTYPE_AUTO_RETURN(
-              base::dispatcher<
+          {
+            return base::dispatcher<
                   true,
                   base::dispatch_result_t<Visitor,
                                           decltype(as_base(
                                               std::forward<Vs>(vs)))...>>::
                   template dispatch_at<0>(index,
                                           std::forward<Visitor>(visitor),
-                                          as_base(std::forward<Vs>(vs))...))
+                                          as_base(std::forward<Vs>(vs))...);
+          }
 #elif !defined(_MSC_VER) || _MSC_VER >= 1910
-          DECLTYPE_AUTO_RETURN(base::at(
+          {
+            return base::at(
               fdiagonal<Visitor &&,
                         decltype(as_base(std::forward<Vs>(vs)))...>::value,
               index)(std::forward<Visitor>(visitor),
-                     as_base(std::forward<Vs>(vs))...))
+                     as_base(std::forward<Vs>(vs))...);
+          }
 #else
-          DECLTYPE_AUTO_RETURN(base::at(
+          {
+            return base::at(
               base::make_fdiagonal<Visitor &&,
                         decltype(as_base(std::forward<Vs>(vs)))...>(),
               index)(std::forward<Visitor>(visitor),
-                     as_base(std::forward<Vs>(vs))...))
+                     as_base(std::forward<Vs>(vs))...);
+          }
 #endif
       };
 
@@ -918,10 +927,12 @@ using is_nothrow_swappable =
           static_assert(visitor<Visitor>::template does_not_handle<Values...>(),
                         "`visit` requires the visitor to be exhaustive.");
 
-          inline static constexpr decltype(auto) invoke(Visitor &&visitor,
-                                                       Values &&... values)
-            DECLTYPE_AUTO_RETURN(invoke(std::forward<Visitor>(visitor),
-                                             std::forward<Values>(values)...))
+          inline static constexpr decltype(auto)
+          invoke(Visitor &&visitor, Values &&... values)
+          {
+            return invoke(std::forward<Visitor>(visitor),
+                          std::forward<Values>(values)...);
+          }
         };
 
         template <typename Visitor>
@@ -930,12 +941,13 @@ using is_nothrow_swappable =
 
           template <typename... Alts>
           inline constexpr decltype(auto) operator()(Alts &&... alts) const
-            DECLTYPE_AUTO_RETURN(
-                visit_exhaustiveness_check<
+          {
+            return visit_exhaustiveness_check<
                     Visitor,
                     decltype((std::forward<Alts>(alts).value))...>::
                     invoke(std::forward<Visitor>(visitor_),
-                           std::forward<Alts>(alts).value...))
+                           std::forward<Alts>(alts).value...);
+          }
         };
 
         template <typename Visitor>
@@ -945,35 +957,37 @@ using is_nothrow_swappable =
 
         public:
         template <typename Visitor, typename... Vs>
-        inline static constexpr decltype(auto) visit_alt(Visitor &&visitor,
-                                                        Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(alt::visit_alt(std::forward<Visitor>(visitor),
-                                              std::forward<Vs>(vs).impl_...))
+        inline static constexpr decltype(auto) visit_alt(Visitor &&visitor, Vs &&... vs)
+        {
+          return alt::visit_alt(std::forward<Visitor>(visitor),
+                                std::forward<Vs>(vs).impl_...);
+        }
 
         template <typename Visitor, typename... Vs>
         inline static constexpr decltype(auto) visit_alt_at(std::size_t index,
                                                            Visitor &&visitor,
                                                            Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(
-              alt::visit_alt_at(index,
-                                std::forward<Visitor>(visitor),
-                                std::forward<Vs>(vs).impl_...))
+        {
+          return alt::visit_alt_at(index, std::forward<Visitor>(visitor),
+                                   std::forward<Vs>(vs).impl_...);
+        }
 
         template <typename Visitor, typename... Vs>
         inline static constexpr decltype(auto) visit_value(Visitor &&visitor,
-                                                          Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(
-              visit_alt(make_value_visitor(std::forward<Visitor>(visitor)),
-                        std::forward<Vs>(vs)...))
+                                                           Vs &&... vs)
+        {
+          return visit_alt(make_value_visitor(std::forward<Visitor>(visitor)),
+                           std::forward<Vs>(vs)...);
+        }
 
         template <typename Visitor, typename... Vs>
         inline static constexpr decltype(auto) visit_value_at(std::size_t index,
                                                              Visitor &&visitor,
                                                              Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(
-              visit_alt_at(index,
-                           make_value_visitor(std::forward<Visitor>(visitor)),
-                           std::forward<Vs>(vs)...))
+        {
+          return visit_alt_at(index, make_value_visitor(std::forward<Visitor>(visitor)),
+                              std::forward<Vs>(vs)...);
+        }
       };
 
     }  // namespace visitation
@@ -1997,7 +2011,6 @@ using is_nothrow_swappable =
   } // namespace detail_variant
 
 #undef AUTO_REFREF_RETURN
-#undef DECLTYPE_AUTO_RETURN
 #undef GUL14_RETURN
 
 } // namespace gul14

--- a/include/gul14/variant.h
+++ b/include/gul14/variant.h
@@ -930,8 +930,8 @@ using is_nothrow_swappable =
           inline static constexpr decltype(auto)
           invoke(Visitor &&visitor, Values &&... values)
           {
-            return invoke(std::forward<Visitor>(visitor),
-                          std::forward<Values>(values)...);
+            return detail_variant::invoke(std::forward<Visitor>(visitor),
+                                          std::forward<Values>(values)...);
           }
         };
 

--- a/tests/test_variant.cc
+++ b/tests/test_variant.cc
@@ -137,3 +137,31 @@ TEST_CASE("variant: variant_size", "[variant]")
     auto v = gul14::variant<float, double, long double>{ };
     REQUIRE(gul14::variant_size<decltype(v)>() == 3);
 }
+
+TEST_CASE("variant: visit()", "[variant]")
+{
+    auto v = gul14::variant<float, double, long>{ };
+
+    auto get_type_name =
+        [](auto&& arg) -> std::string
+        {
+            using T = std::decay_t<decltype(arg)>;
+            if (std::is_same<T, float>::value)
+                return "float";
+            else if (std::is_same<T, double>::value)
+                return "double";
+            else if (std::is_same<T, long>::value)
+                return "long";
+            else
+                return "FAIL";
+        };
+
+    v = 1.5f;
+    REQUIRE(gul14::visit(get_type_name, v) == "float");
+
+    v = 2.4;
+    REQUIRE(gul14::visit(get_type_name, v) == "double");
+
+    v = 42L;
+    REQUIRE(gul14::visit(get_type_name, v) == "long");
+}


### PR DESCRIPTION
It seems I underestimated the import of the `variant` header. In fact, `gul14::visit()` could not be used at all (at least for some set of compilers) because of a missing namespace qualifier on one call to `invoke()`. Here's a bugfix.