### PR TITLE
CI: Really trigger on PRs

### DIFF
--- a/.github/workflows/testposix.yml
+++ b/.github/workflows/testposix.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     branches: [ main ]
     paths:
-      - 'include'
-      - 'src'
-      - 'tests'
-      - 'tools'
+      - 'include/**'
+      - 'src/**'
+      - 'tests/**'
+      - 'tools/**'
+      - 'meson.build'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/testwindows.yml
+++ b/.github/workflows/testwindows.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     branches: [ main ]
     paths:
-      - 'include'
-      - 'src'
-      - 'tests'
-      - 'tools'
+      - 'include/**'
+      - 'src/**'
+      - 'tests/**'
+      - 'tools/**'
+      - 'meson.build'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
[why]
The test workflows are not triggered on PRs.

[how]
Correct the path filter... forgot the glob.

Also add meson.build to the filter, as changes there might also break builds.

Noticed when reviewing #50 