### PR TITLE
meson: enable more warnings by default

### DIFF
--- a/debian/meson.build
+++ b/debian/meson.build
@@ -37,7 +37,8 @@ changelg_run = run_command(
     changelogger,
     get_option('deb-vers-pack') ? '-tp' : '-t',
     get_option('deb-vers-tag') + '*',
-    changelog_gen
+    changelog_gen,
+    check: true,
 )
 
 if changelg_run.returncode() != 0

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,12 @@ project('gul14', 'cpp',
     version : '2.9',
     meson_version : '>=0.48')
 
+# Enable additional warnings by default
+if host_machine.system() != 'windows'
+    # Both GCC and clang know how to handle these options
+    add_global_arguments('-Wshadow', '-Wconversion', language: [ 'cpp' ])
+endif
+
 # Enforce that the version number is according to specs
 version_parts = meson.project_version().split('.')
 libgul_api_version = '@0@.@1@'.format(version_parts[0], version_parts[1])

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,7 +18,8 @@ if git_exe.found()
     # Get full description based on git tag API version ('v0.2-22-g3d8867c-dirty')
     git_f_api = run_command(
         git_exe, '-C', meson.current_source_dir(),
-            'describe', '--tags', '--always', '--dirty', '--match', 'v*'
+            'describe', '--tags', '--always', '--dirty', '--match', 'v*',
+        check: false
     )
     if git_f_api.returncode() != 0
         git_full_api_version = 'unknown'
@@ -33,7 +34,8 @@ if git_exe.found()
     git_vers = run_command(
         git_exe, '-C', meson.current_source_dir(),
             'describe', '--tags', '--always', '--abbrev=0', '--match',
-            get_option('deb-vers-tag') + '*'
+            get_option('deb-vers-tag') + '*',
+        check: false
     )
     if git_vers.returncode() != 0
         git_version = 'unknown'
@@ -53,7 +55,8 @@ if git_exe.found()
     # Get the number of commits since the relevant version tag
     git_pat = run_command(
         git_exe, '-C', meson.current_source_dir(),
-            'rev-list', '--count', git_version + '..'
+            'rev-list', '--count', git_version + '..',
+        check: false
     )
     if git_pat.returncode() == 0
         # Ignore patchlevel if it is zero


### PR DESCRIPTION
This will enable more warnings by default. As of right now this will not trigger any new warnings.