### PR TITLE
Add OverloadSet and make_overload_set()

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -143,6 +143,11 @@ namespace gul14 {
  *
  * \section changelog_2_x 2.x Versions
  *
+ * \subsection v2_9_2 Version 2.9.2
+ *
+ * - Add OverloadSet and make_overload_set()
+ * - Fix compilation errors in gul14::visit()
+ *
  * \subsection v2_9_1 Version 2.9.1
  *
  * - Fix compilation errors in gul14::variant when compiled with C++17 or MSVC

--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -44,7 +44,7 @@ namespace gul14 {
  *  - \ref numeric_utilities
  *  - \ref container_utilities
  *  - \ref GSL_utilities
- *  - \ref type_traits
+ *  - \ref metaprogramming
  *  - \ref standard_library_backports
  *  - \ref unit_tests
  *
@@ -587,12 +587,16 @@ namespace gul14 {
  */
 
 /**
- * \page type_traits Type Traits
+ * \page metaprogramming Metaprogramming Utilities and Type Traits
  *
- * The library provides a few type traits that can be useful for template metaprogramming.
+ * The library provides some utilities for template metaprogramming:
  *
  * \ref gul14::IsContainerLike "IsContainerLike":
  *     A type trait to determine if a type behaves like a standard container.
+ *
+ * \ref gul14::OverloadSet "OverloadSet" and \ref gul14::make_overload_set "make_overload_set()":
+ *     A function object type that works like an overload set of functions, and a helper
+ *     function to create such an object from a bunch of lambdas.
  *
  * \ref gul14::remove_cvref "remove_cvref":
  *     A metafunction to remove const, volatile, and reference qualifiers from a type.

--- a/tests/test_variant.cc
+++ b/tests/test_variant.cc
@@ -165,3 +165,26 @@ TEST_CASE("variant: visit()", "[variant]")
     v = 42L;
     REQUIRE(gul14::visit(get_type_name, v) == "long");
 }
+
+TEST_CASE("make_overload_set()", "[variant]")
+{
+    auto v = gul14::variant<float, double, long, std::string>{ };
+
+    auto get_type_name = gul14::make_overload_set(
+        [](auto&&) -> std::string { return "SOMETHING ELSE"; },
+        [](float) -> std::string { return "float"; },
+        [](double) -> std::string { return "double"; },
+        [](long) -> std::string { return "long"; });
+
+    v = 1.5f;
+    REQUIRE(gul14::visit(get_type_name, v) == "float");
+
+    v = 2.4;
+    REQUIRE(gul14::visit(get_type_name, v) == "double");
+
+    v = 42L;
+    REQUIRE(gul14::visit(get_type_name, v) == "long");
+
+    v = "Test";
+    REQUIRE(gul14::visit(get_type_name, v) == "SOMETHING ELSE");
+}


### PR DESCRIPTION
This PR adds the `OverloadSet` variadic class template and a `make_overload_set()` helper function to create objects of this type. Such a type is recommended for use with `std::visit` by Bjarne Stroustrup in "A Tour of C++" where he writes that "[t]he **overloaded** class is necessary and strangely enough, not standard". Well, at least we should have it. :)

I think we should squeeze this in as patch release 2.9.2. Yes, we enhance the API, but since this is header-only stuff, users can safely ignore it.
  
# [why]
Without C++17, we do not have "if constexpr". This can make it hard to
construct a suitable visitor function for gul14::visit(). The
alternative to using "if constexpr" is constructing an overload set of
functions.
    
# [how]
Provide a variadic class template OverloadSet that inherits from an
arbitrary number of function objects (typically lambdas) and imports
their definitions of operator() into an overload set for its own
operator(). Because constructing such an OverloadSet object manually is
almost impossible without C++17's advanced template argument deduction,
we also provide a helper function make_overload_set() to take care of
that.