### PR TITLE
meson: Do not use global arguments when subproject

### DIFF
--- a/debian/meson.build
+++ b/debian/meson.build
@@ -38,7 +38,7 @@ changelg_run = run_command(
     get_option('deb-vers-pack') ? '-tp' : '-t',
     get_option('deb-vers-tag') + '*',
     changelog_gen,
-    check: true,
+    check: false,
 )
 
 if changelg_run.returncode() != 0

--- a/meson.build
+++ b/meson.build
@@ -11,12 +11,6 @@ project('gul14', 'cpp',
     version : '2.9',
     meson_version : '>=0.48')
 
-# Enable additional warnings by default
-if host_machine.system() != 'windows'
-    # Both GCC and clang know how to handle these options
-    add_global_arguments('-Wshadow', '-Wconversion', language: [ 'cpp' ])
-endif
-
 # Enforce that the version number is according to specs
 version_parts = meson.project_version().split('.')
 libgul_api_version = '@0@.@1@'.format(version_parts[0], version_parts[1])


### PR DESCRIPTION
When we use libgul as subproject the setup will fail with:
> ERROR: Function 'add_global_arguments' cannot be used in subprojects because there is no way to make that reliable.

Fixes: 114b594a821 (meson: Enable extra warnings by default)