### PR TITLE
Features for determining platform endianness

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -42,6 +42,7 @@ namespace gul14 {
  *  - \ref statistics_utilities
  *  - \ref debugging_utilities
  *  - \ref numeric_utilities
+ *  - \ref bit_manipulation
  *  - \ref container_utilities
  *  - \ref GSL_utilities
  *  - \ref metaprogramming
@@ -142,6 +143,11 @@ namespace gul14 {
  * \page release_notes Release Notes
  *
  * \section changelog_2_x 2.x Versions
+ *
+ * \subsection v2_10_0 Version 2.10.0
+ *
+ * - Add gul14::endian, a backport of std::endian from C++20
+ * - Add gul14::is_little_endian() and gul14::is_big_endian()
  *
  * \subsection v2_9_2 Version 2.9.2
  *
@@ -537,8 +543,6 @@ namespace gul14 {
 /**
  * \page numeric_utilities Numeric Utilities
  *
- * The General Utility Library provides several functions dealing with numbers.
- *
  * <h4>Modifying Values</h4>
  *
  * abs():
@@ -570,6 +574,10 @@ namespace gul14 {
  * within_ulp():
  *     Determine if two numbers are almost equal, allowing for a difference of a given
  *     number of units-in-the-last-place (ULPs).
+ */
+
+/**
+ * \page bit_manipulation Bit Manipulation and Testing
  *
  * <h4>Working With Bits in Integral Values</h4>
  *
@@ -584,6 +592,19 @@ namespace gul14 {
  *
  * bit_test():
  *     Test a bit in an integral value.
+ *
+ * <h4>Endianness</h4>
+ *
+ * \ref gul14::endian "endian":
+ *     An enum to determine the endianness of multi-byte scalars on the current platform,
+ *     behaving like [std::endian](https://en.cppreference.com/w/cpp/types/endian) from
+ *     C++20.
+ *
+ * is_big_endian():
+ *     Determine if the current platform uses big-endian byte order.
+ *
+ * is_little_endian():
+ *     Determine if the current platform uses little-endian byte order.
  */
 
 /**
@@ -615,6 +636,11 @@ namespace gul14 {
  *
  * The General Utility Library provides a few classes from the C++ standard library that
  * are not yet available to users of older compilers.
+ *
+ * \ref gul14::endian "endian":
+ *     An enum to determine the endianness of multi-byte scalars on the current platform,
+ *     behaving like [std::endian](https://en.cppreference.com/w/cpp/types/endian) from
+ *     C++20.
  *
  * \ref gul14::expected "expected":
  *     A class template that can either contain a value of a certain (expected) type or an

--- a/include/gul14/bit_manip.h
+++ b/include/gul14/bit_manip.h
@@ -33,7 +33,7 @@ namespace gul14 {
 
 /**
  * \addtogroup bit_manip_h gul14/bit_manip.h
- * \brief Bit manipulation.
+ * \brief Bit manipulation and testing, endianness.
  * @{
  */
 
@@ -56,6 +56,44 @@ using BitFunctionReturnType =
             and not std::is_same<std::decay_t<T>, bool>::value,
         std::decay_t<T>
     >;
+
+/**
+ * An enum to determine the endianness of multi-byte scalars on the current platform.
+ *
+ * In big-endian (Motorola) order, the most significant byte is stored first, followed by
+ * the other bytes in order of decreasing significance. Little-endian platforms (e.g.
+ * Intel) store the bytes in the opposite order. There are also (historical) platforms
+ * which do not conform to either of these conventions.
+ *
+ * \code{.cpp}
+ *  if constexpr (gul14::endian::native == gul14::endian::big)
+ *      std::cout << "This is a big-endian machine!\n";
+ * \endcode
+ *
+ * This is a backport of [std::endian](https://en.cppreference.com/w/cpp/types/endian)
+ * from C++20.
+ *
+ * \see is_big_endian(), is_little_endian()
+ * \since GUL version 2.10
+ */
+enum class endian
+{
+#if defined(__BYTE_ORDER__)
+    little = __ORDER_LITTLE_ENDIAN__,
+    big    = __ORDER_BIG_ENDIAN__,
+    native = __BYTE_ORDER__
+#elif defined(_MSC_VER) && !defined(__clang__)
+    little = 0,
+    big    = 1,
+    native = little
+#else
+    #error "Don't know how to determine machine endianness on this compiler"
+    // Just for Doxygen:
+    little, ///< Little-endian (e.g. Intel)
+    big,    ///< Big-endian (e.g. Motorola)
+    native  ///< Native endianness
+#endif
+};
 
 /**
  * Set a bit in an integral type.
@@ -185,6 +223,36 @@ auto constexpr inline bit_flip(T previous, unsigned bit) noexcept -> ReturnT {
 template <typename T>
 bool constexpr inline bit_test(T bits, unsigned bit) noexcept {
     return bits & bit_set<T>(bit);
+}
+
+/**
+ * Determine whether this platform uses big-endian (Motorola) order for storing multi-byte
+ * quantities in memory.
+ *
+ * In big-endian order, the most significant byte is stored first, followed by the other
+ * bytes in order of decreasing significance.
+ *
+ * \see is_little_endian(), gul14::endian
+ * \since GUL version 2.10
+ */
+constexpr bool is_big_endian()
+{
+    return endian::native == endian::big;
+}
+
+/**
+ * Determine whether this platform uses little-endian (Intel) order for storing multi-byte
+ * quantities in memory.
+ *
+ * In little-endian order, the least significant byte is stored first, followed by the
+ * other bytes in order of increasing significance.
+ *
+ * \see is_big_endian(), gul14::endian
+ * \since GUL version 2.10
+ */
+constexpr bool is_little_endian()
+{
+    return endian::native == endian::little;
 }
 
 /// @}

--- a/tests/test_bit_manip.cc
+++ b/tests/test_bit_manip.cc
@@ -4,7 +4,7 @@
  * \date   Created on 17 Oct 2019
  * \brief  Unit tests for bit_set(), bit_reset(), bit_flip(), bit_test().
  *
- * \copyright Copyright 2019 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2019-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -74,6 +74,11 @@ TEMPLATE_TEST_CASE("Access MSB", "[bit_manip]",
 
     REQUIRE(gul14::bit_test(x, msb) == true);
     REQUIRE(gul14::bit_test(x, msb - 1) == false);
+}
+
+TEST_CASE("is_little_endian(), is_big_endian()", "[bit_manip]")
+{
+    REQUIRE(gul14::is_little_endian() != gul14::is_big_endian());
 }
 
 // vi:ts=4:sw=4:sts=4:et

--- a/tests/test_bit_manip.cc
+++ b/tests/test_bit_manip.cc
@@ -79,6 +79,24 @@ TEMPLATE_TEST_CASE("Access MSB", "[bit_manip]",
 TEST_CASE("is_little_endian(), is_big_endian()", "[bit_manip]")
 {
     REQUIRE(gul14::is_little_endian() != gul14::is_big_endian());
+
+    const std::uint32_t val = 0x01'02'03'04;
+    const char* chars = reinterpret_cast<const char*>(&val);
+
+    if (gul14::is_little_endian())
+    {
+        REQUIRE(chars[0] == 4);
+        REQUIRE(chars[1] == 3);
+        REQUIRE(chars[2] == 2);
+        REQUIRE(chars[3] == 1);
+    }
+    else if (gul14::is_big_endian())
+    {
+        REQUIRE(chars[0] == 1);
+        REQUIRE(chars[1] == 2);
+        REQUIRE(chars[2] == 3);
+        REQUIRE(chars[3] == 4);
+    }
 }
 
 // vi:ts=4:sw=4:sts=4:et


### PR DESCRIPTION
This PR adds an enum class `gul14::endian` that works like C++20's [std::endian](https://en.cppreference.com/w/cpp/types/endian) and two convenience functions `is_little_endian()` and `is_big_endian()`. Together, this offers a simple and portable solution to enquire the system's endianness at compile time.

The PR also separates the documentation for the bit manipulation functions from the numeric functions.