### PR TITLE
Update GitHub actions and Meson version

### DIFF
--- a/.github/workflows/testposix.yml
+++ b/.github/workflows/testposix.yml
@@ -41,19 +41,19 @@ jobs:
         id: cache-meson
         uses: actions/cache@v4
         with:
-          path: meson-0.63.0
-          key: meson-0.63.0
+          path: meson-1.3.1
+          key: meson-1.3.1
 
       - name: Download Meson
         if: steps.cache-meson.outputs.cache-hit != 'true'
         run: |
-          wget -q https://github.com/mesonbuild/meson/releases/download/0.63.0/meson-0.63.0.tar.gz
-          tar -xzf meson-0.63.0.tar.gz
-          rm meson-0.63.0.tar.gz
+          wget -q https://github.com/mesonbuild/meson/releases/download/1.3.1/meson-1.3.1.tar.gz
+          tar -xzf meson-1.3.1.tar.gz
+          rm meson-1.3.1.tar.gz
 
       - name: Create symbolic link for Meson
         run: |
-          ln -s meson-0.63.0/meson.py .
+          ln -s meson-1.3.1/meson.py .
           ls -la
 
       - name: Configure build directories

--- a/.github/workflows/testposix.yml
+++ b/.github/workflows/testposix.yml
@@ -23,7 +23,7 @@ jobs:
         run: echo "Branch ${{ github.ref }} on repository ${{ github.repository }}"
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Ninja
         shell: bash
@@ -39,7 +39,7 @@ jobs:
 
       - name: Retrieve Meson from cache
         id: cache-meson
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: meson-0.63.0
           key: meson-0.63.0
@@ -67,7 +67,7 @@ jobs:
       - name: Build and run release tests
         run: ./meson.py test -C build.release
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: build-dirs-${{ matrix.platform }}

--- a/.github/workflows/testwindows.yml
+++ b/.github/workflows/testwindows.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "Branch ${{ github.ref }} on repository ${{ github.repository }}"
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -54,7 +54,7 @@ jobs:
         if: false
         run: meson test -C build.asan
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: build-dirs


### PR DESCRIPTION
GitHub complains about outdated actions:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3, actions/upload-artifact@v3.

We now use the v4 versions of these actions. At the same time, we update Meson from 0.63.0 to 1.3.1.