### PR TITLE
meson: Fix deprecated warning

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -17,12 +17,12 @@ if get_option('docs') and doxygen.found() and graphviz.found() and doxy_run.foun
         configuration : docs_data,
     )
 
-    docs_outdir = join_paths(meson.current_build_dir(), 'doxygenerated')
+    docs_outdir = meson.current_build_dir() / 'doxygenerated'
 
     docs_gen = custom_target('doxy_generate', # This is not the ninja target name
         command : [
             doxy_run, # "Usage: doxywrap source_root output_root config_file [doxygen parameters]"
-            join_paths(meson.current_source_dir(), '..'),
+            meson.current_source_dir() / '..',
             docs_outdir,
             '@INPUT@',
         ],
@@ -34,17 +34,14 @@ if get_option('docs') and doxygen.found() and graphviz.found() and doxy_run.foun
         )
 
     if rsync.found()
-        docdir = join_paths(
-            get_option('prefix'),
-            get_option('datadir'),
-            meson.project_name())
+        docdir = get_option('prefix') / get_option('datadir') / meson.project_name()
 
         custom_target('copy_doxygenerated',
             command : [
                 rsync,
                 '-rt',
                 '--chmod=Da=rx,ug+w,Fa=r,ug+w',
-                join_paths(docs_outdir, 'html'),
+                docs_outdir / 'html',
                 docdir,
             ],
             input : docs_gen,

--- a/debian/control.in
+++ b/debian/control.in
@@ -1,7 +1,7 @@
 Source: @NAME@
 Priority: optional
 Maintainer: Fini Jastrow <ulf.fini.jastrow@desy.de>
-Build-Depends: debhelper (>=9), meson (>=0.48), ninja-build (>=1.5.1)
+Build-Depends: debhelper (>=9), meson (>=0.49), ninja-build (>=1.5.1)
 Standards-Version: 3.9.7
 Section: libs
 Homepage: https://stash.desy.de/projects/GUL/repos/libgul

--- a/debian/meson.build
+++ b/debian/meson.build
@@ -32,7 +32,7 @@ if not changelogger.found()
     error('Debian changelog generator not found')
 endif
 
-changelog_gen = join_paths(meson.current_build_dir(), 'changelog.gen')
+changelog_gen = meson.current_build_dir() / 'changelog.gen'
 changelg_run = run_command(
     changelogger,
     get_option('deb-vers-pack') ? '-tp' : '-t',

--- a/debian/meson.build
+++ b/debian/meson.build
@@ -63,7 +63,7 @@ deb_conf.set('NAME-DEV', deb_dev_name)
 deb_conf.set('CONFLICTS', '')
 deb_conf.set('CONFLICTS-DEV', '')
 deb_conf.set('VERSION', debian_package_version)
-deb_conf.set('CONFIG_CHECKER', meson.build_root() + '/@0@'.format(config_checker))
+deb_conf.set('CONFIG_CHECKER', config_checker_path)
 deb_conf.set('NINJA-ARGS', get_variable('deb_ninja_args', ''))
 
 # Mark a conflict, if we generate a non standard debian package

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project('gul14', 'cpp',
         'warning_level=3',
     ],
     version : '2.10',
-    meson_version : '>=0.48')
+    meson_version : '>=0.49')
 
 # Enforce that the version number is according to specs
 version_parts = meson.project_version().split('.')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -70,7 +70,7 @@ foreach header_to_check : standalone_headers
         header_name = header_to_check.split('.h')[0]
 
         header_conf = configuration_data()
-        header_conf.set('HEADER_TO_INCLUDE', meson.project_name() + '/' + header_to_check)
+        header_conf.set('HEADER_TO_INCLUDE', meson.project_name() / header_to_check)
         header_conf.set('DUMMY_FUNCTION_NAME', 'a@0@'.format(loop_number))
 
         header_check = configure_file(

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -26,6 +26,6 @@ config_checker = configure_file(
     output : 'config_checker',
     configuration : check_conf,
 )
-config_checker_path = meson.current_build_dir() + '/config_checker'
+config_checker_path = meson.current_build_dir() / '/config_checker'
 
 # vi:ts=4:sw=4:sts=4:et:syn=conf

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -26,5 +26,6 @@ config_checker = configure_file(
     output : 'config_checker',
     configuration : check_conf,
 )
+config_checker_path = meson.current_build_dir() + '/config_checker'
 
 # vi:ts=4:sw=4:sts=4:et:syn=conf


### PR DESCRIPTION
**[why]**
Meson 1.3.99 gives these warnings:
```
NOTICE: Future-deprecated features used:
 * 0.56.0: {'meson.build_root'}
WARNING: Broken features used:
 * 1.3.0: {'str.format: Value other than strings, integers, bools, options, dictionaries and lists thereof.'}
```

**[how]**
We try to get the absolute path of a generated file. Since 1.4.0 we have a `get_path()` member function on the generated file object, but we can not use that on older Mesons.

So instead we just manually assemble the filename in the place where the file is generated and use that later on. Both warned-about functions removed.

Fixes: #64