### PR TITLE
string_view: Fix signed mismatch warning

### DIFF
--- a/.github/workflows/testwindows.yml
+++ b/.github/workflows/testwindows.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/include/gul14/string_view.h
+++ b/include/gul14/string_view.h
@@ -297,7 +297,7 @@ public:
             return npos;
         const_iterator iter = std::find_first_of
                 (this->cbegin () + pos, this->cend (), s.cbegin (), s.cend (), traits::eq);
-        return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
+        return iter == this->cend () ? npos : static_cast< size_type >(std::distance ( this->cbegin (), iter ));
     }
     constexpr size_type find_first_of(charT c, size_type pos = 0) const noexcept
     { return find_first_of(basic_string_view(&c, 1), pos); }
@@ -316,7 +316,7 @@ public:
             pos = len_ - (pos+1);
         const_reverse_iterator iter = std::find_first_of
                 ( this->crbegin () + pos, this->crend (), s.cbegin (), s.cend (), traits::eq );
-        return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter);
+        return iter == this->crend () ? npos : ( len_ - 1 - static_cast< size_type >(std::distance( this->crbegin (), iter )) );
     }
     constexpr size_type find_last_of(charT c, size_type pos = npos) const noexcept
     { return find_last_of(basic_string_view(&c, 1), pos); }
@@ -332,7 +332,7 @@ public:
         if (s.len_ == 0)
             return pos;
         const_iterator iter = find_not_of ( this->cbegin () + pos, this->cend (), s );
-        return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
+        return iter == this->cend () ? npos : static_cast< size_type >(std::distance ( this->cbegin (), iter ));
     }
     constexpr size_type find_first_not_of(charT c, size_type pos = 0) const noexcept
     { return find_first_not_of(basic_string_view(&c, 1), pos); }
@@ -348,8 +348,8 @@ public:
         if (s.len_ == 0u)
             return pos;
         pos = len_ - (pos+1);
-        const_reverse_iterator iter = find_not_of ( this->crbegin () + pos, this->crend (), s );
-        return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
+        const_reverse_iterator iter = find_not_of ( this->crbegin () + static_cast< difference_type >(pos), this->crend (), s );
+        return iter == this->crend () ? npos : ( len_ - 1 - static_cast< size_type >(std::distance( this->crbegin (), iter )) );
     }
     constexpr size_type find_last_not_of(charT c, size_type pos = npos) const noexcept
     { return find_last_not_of(basic_string_view(&c, 1), pos); }
@@ -359,12 +359,6 @@ public:
     { return find_last_not_of(basic_string_view(s), pos); }
 
 private:
-    template <typename r_iter>
-    size_type reverse_distance(r_iter first, r_iter last) const noexcept {
-        // Portability note here: std::distance is not NOEXCEPT, but calling it with a string_view::reverse_iterator will not throw.
-        return len_ - 1 - std::distance ( first, last );
-    }
-
     template <typename Iterator>
     Iterator find_not_of(Iterator first, Iterator last, basic_string_view s) const noexcept {
         for (; first != last ; ++first)

--- a/include/gul14/string_view.h
+++ b/include/gul14/string_view.h
@@ -168,7 +168,7 @@ public:
     // element access
     constexpr const_reference operator[](size_type pos) const noexcept { return ptr_[pos]; }
 
-    constexpr const_reference at(size_t pos) const {
+    constexpr const_reference at(size_type pos) const {
         return pos >= len_ ?  throw std::out_of_range("gul14::string_view::at") : ptr_[pos];
     }
 
@@ -368,7 +368,7 @@ private:
     }
 
     const charT *ptr_;
-    std::size_t len_;
+    size_type len_;
 };
 
 /// \cond HIDE_SYMBOLS


### PR DESCRIPTION
**[why]**
Apple clang version 15.0.0 warns:

```
warning: implicit conversion changes signedness:
    'size_type' (aka 'unsigned long') to 'difference_type' (aka 'long')
    [-Wsign-conversion]
```

**[how]**
_Distances_ can be forward and backward and thus need a signed number.
_Size and index_ is often described by an unsigned number, to double the range and to avoid meaningless negative length.

This has historically been mixed without much thought, although in extreme cases the results were wrong. But usually we do not have strings that long.

To fix this first the private `reverse_distance()` function is removed, because it returns a unsigned number and must return a unsigned number from what it does internally and that does not reflect the concept of 'distance'.

Instead we take the forward distance and do the 'harder' calculations in the places where `reverse_distance()` has been used (2 places).

There are now 4 instances of mixing distance and size/index. Upon careful check it is impossible that the distance in these cases can become negative; so that we can remove the sign in confidence. This is expressed by `static_casting` to the `size_type`, whereupon the warnings disappear.

Fixes: #65