### PR TITLE
Provide backports of std::invoke, invoke_result, is_invokable and friends

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -144,6 +144,11 @@ namespace gul14 {
  *
  * \section changelog_2_x 2.x Versions
  *
+ * \subsection v2_11_0 Version 2.11.0
+ *
+ * - Add backports of std::invoke, std::invoke_result, std::invoke_result_t,
+ *   std::is_invocable, and std::is_invocable_r from C++17
+ *
  * \subsection v2_10_0 Version 2.10.0
  *
  * - Add gul14::endian, a backport of std::endian from C++20
@@ -296,7 +301,7 @@ namespace gul14 {
  *
  * \section copyright_notice Copyright Notice
  *
- * Copyright 2018-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -348,6 +353,13 @@ namespace gul14 {
  * <dd>Copyright 2012-2015 Marshall Clow, copyright 2015 Beman Dawes.
  *     Distributed under the Boost Software License, Version 1.0 (see
  *     \ref license_boost_1_0 and \ref string_view.h for details).</dd>
+ *
+ * <dt>\ref traits.h</dt>
+ * <dd>Copyright 2015-2017 Michael Park (implementations of invoke, invoke_result,
+ *     invoke_result_t, is_invocable, is_invocable_r), copyright 2021-2024 Deutsches
+ *     Elektronen-Synchrotron (DESY), Hamburg (other implementations and modifications).
+ *     Distributed under the Boost Software License, Version 1.0 (see
+ *     \ref license_boost_1_0 and \ref traits.h for details).</dd>
  *
  * <dt>\ref variant.h</dt>
  * <dd>Copyright 2015-2017 Michael Park.
@@ -611,6 +623,24 @@ namespace gul14 {
  * \page metaprogramming Metaprogramming Utilities and Type Traits
  *
  * The library provides some utilities for template metaprogramming:
+ *
+ * \ref gul14::invoke "invoke":
+ *     A function template that calls a callable object with a given set of arguments.
+ *     This is a backport of
+ *     [std::invoke](https://en.cppreference.com/w/cpp/utility/functional/invoke) from
+ *     C++17.
+ *
+ * \ref gul14::invoke_result "invoke_result", \ref gul14::invoke_result_t "invoke_result_t":
+ *     A metafunction that computes the result of invoking a callable object with the
+ *     given arguments. This is a backport of
+ *     [std::invoke_result](https://en.cppreference.com/w/cpp/types/result_of) from
+ *     C++17.
+ *
+ * \ref gul14::is_invocable "is_invocable", \ref gul14::is_invocable_r "is_invocable_r":
+ *     A type trait that checks whether a callable object can be invoked with a given set
+ *     of arguments. This is a backport of
+ *     [std::is_invocable](https://en.cppreference.com/w/cpp/types/is_invocable) from
+ *     C++17.
  *
  * \ref gul14::IsContainerLike "IsContainerLike":
  *     A type trait to determine if a type behaves like a standard container.

--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -362,7 +362,8 @@ namespace gul14 {
  *     \ref license_boost_1_0 and \ref traits.h for details).</dd>
  *
  * <dt>\ref variant.h</dt>
- * <dd>Copyright 2015-2017 Michael Park.
+ * <dd>Copyright 2015-2017 Michael Park, copyright 2023-2024 Deutsches
+ *     Elektronen-Synchrotron (DESY), Hamburg.
  *     Distributed under the Boost Software License, Version 1.0 (see
  *     \ref license_boost_1_0 and \ref variant.h for details).</dd>
  * </dl>

--- a/debian/copyright.in
+++ b/debian/copyright.in
@@ -1,34 +1,54 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: *
-Copyright: 2018-2023 libgul contributors
-           2018-2023 DESY
+Copyright: 2018-2024 libgul contributors
+           2018-2024 DESY
 License: LGPL-2.1+
+
+Files: include/gul14/catch.h
+Copyright: 2019 Two Blue Cubes Ltd.
+License: BSL-1.0
+
+Files: include/gul14/date.h
+Copyright: 2015-2017 Howard Hinnant
+           2016 Adrian Colomitchi
+           2017 Florian Dang
+           2017 Paul Thompson
+           2018-2019 Tomasz Kamiński
+           2019 Jiangang Zhuang
+           2022 libgul contributors (L. Fröhlich)
+License: Expat
+
+Files: include/gul14/expected.h
+Copyright: 2017 Sy Brand
+           2023-2024 libgul contributors (L. Fröhlich)
+License: CC0
+
+Files: include/gul14/optional.h
+Copyright: 2011-2012 Andrzej Krzemienski
+           2019 libgul contributors (L. Fröhlich)
+License: BSL-1.0
+
+Files: include/gul14/span.h
+Copyright: 2018 Tristan Brindle
+           2019 libgul contributors (L. Fröhlich)
+License: BSL-1.0
 
 Files: include/gul14/string_view.h
 Copyright: 2012-2015 Marshall Clow
            2015 Beman Dawes
-           2018 libgul contributors (L. Froehlich)
-License: BOOST-1
+           2018 libgul contributors (L. Fröhlich)
+License: BSL-1.0
 
-Files: include/gul14/catch.h
-Copyright: 2019 Two Blue Cubes Ltd.
-License: BOOST-1
+Files: include/gul14/traits.h
+Copyright: 2015-2017 Michael Park
+           2021-2024 libgul contributors (L. Fröhlich, U.F. Jastrow)
+License: BSL-1.0
 
-Files: include/gul14/optional.h
-Copyright: 2011-2012 Andrzej Krzemienski
-           2019 libgul contributors (L. Froehlich)
-License: BOOST-1
-
-Files: include/gul14/span.h
-Copyright: 2018 Tristan Brindle
-           2019 libgul contributors (L. Froehlich)
-License: BOOST-1
-
-Files: include/gul14/expected.h
-Copyright: 2017 Sy Brand
-           2023 libgul contributors (L. Froehlich)
-License: CC0
+Files: include/gul14/variant.h
+Copyright: 2015-2017 Michael Park
+           2023-2024 libgul contributors (L. Fröhlich)
+License: BSL-1.0
 
 License: LGPL-2.1+
  This package is free software; you can redistribute it and/or
@@ -45,7 +65,7 @@ License: LGPL-2.1+
  License along with this package; if not, write to the Free Software
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
-License: BOOST-1
+License: BSL-1.0
  Boost Software License - Version 1.0 - August 17th, 2003
  .
  Permission is hereby granted, free of charge, to any person or organization
@@ -69,6 +89,26 @@ License: BOOST-1
  FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  DEALINGS IN THE SOFTWARE.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 License: CC0
  Creative Commons Legal Code – CC0 1.0 Universal

--- a/include/gul14/traits.h
+++ b/include/gul14/traits.h
@@ -106,7 +106,7 @@ using std::is_invocable_r;
 
 namespace detail_invoke {
 
-#define GUL14_RETURN(...) \
+#define GUL14_INVOKE_RETURN(...) \
   noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { return __VA_ARGS__; }
 
 template <typename T>
@@ -123,55 +123,54 @@ template <>
 struct Invoke<true /* pmf */, 0 /* is_base_of */> {
     template <typename R, typename T, typename Arg, typename... Args>
     inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
-    GUL14_RETURN((std::forward<Arg>(arg).*pmf)(std::forward<Args>(args)...))
+    GUL14_INVOKE_RETURN((std::forward<Arg>(arg).*pmf)(std::forward<Args>(args)...))
 };
 
 template <>
 struct Invoke<true /* pmf */, 1 /* is_reference_wrapper */> {
     template <typename R, typename T, typename Arg, typename... Args>
     inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
-    GUL14_RETURN((std::forward<Arg>(arg).get().*pmf)(std::forward<Args>(args)...))
+    GUL14_INVOKE_RETURN((std::forward<Arg>(arg).get().*pmf)(std::forward<Args>(args)...))
 };
 
 template <>
 struct Invoke<true /* pmf */, 2 /* otherwise */> {
     template <typename R, typename T, typename Arg, typename... Args>
     inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
-    GUL14_RETURN(((*std::forward<Arg>(arg)).*pmf)(std::forward<Args>(args)...))
+    GUL14_INVOKE_RETURN(((*std::forward<Arg>(arg)).*pmf)(std::forward<Args>(args)...))
 };
 
 template <>
 struct Invoke<false /* pmo */, 0 /* is_base_of */> {
     template <typename R, typename T, typename Arg>
     inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
-    GUL14_RETURN(std::forward<Arg>(arg).*pmo)
+    GUL14_INVOKE_RETURN(std::forward<Arg>(arg).*pmo)
 };
 
 template <>
 struct Invoke<false /* pmo */, 1 /* is_reference_wrapper */> {
     template <typename R, typename T, typename Arg>
     inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
-    GUL14_RETURN(std::forward<Arg>(arg).get().*pmo)
+    GUL14_INVOKE_RETURN(std::forward<Arg>(arg).get().*pmo)
 };
 
 template <>
 struct Invoke<false /* pmo */, 2 /* otherwise */> {
     template <typename R, typename T, typename Arg>
     inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
-        GUL14_RETURN((*std::forward<Arg>(arg)).*pmo)
+        GUL14_INVOKE_RETURN((*std::forward<Arg>(arg)).*pmo)
 };
 
 template <typename R, typename T, typename Arg, typename... Args>
 inline constexpr auto invoke(R T::*f, Arg&& arg, Args&&... args)
-    GUL14_RETURN(
+    GUL14_INVOKE_RETURN(
         Invoke<std::is_function<R>::value,
                 (std::is_base_of<T, std::decay_t<Arg>>::value
                     ? 0
                     : is_reference_wrapper<std::decay_t<Arg>>::value
                         ? 1
-                        : 2)>::invoke(f,
-                                        std::forward<Arg>(arg),
-                                        std::forward<Args>(args)...))
+                        : 2)>::invoke(f, std::forward<Arg>(arg),
+                                      std::forward<Args>(args)...))
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -179,12 +178,12 @@ inline constexpr auto invoke(R T::*f, Arg&& arg, Args&&... args)
 #endif
 template <typename F, typename... Args>
 inline constexpr auto invoke(F &&f, Args &&... args)
-    GUL14_RETURN(std::forward<F>(f)(std::forward<Args>(args)...))
+    GUL14_INVOKE_RETURN(std::forward<F>(f)(std::forward<Args>(args)...))
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
-#undef GUL14_RETURN
+#undef GUL14_INVOKE_RETURN
 
 } // namespace detail_invoke
 

--- a/include/gul14/traits.h
+++ b/include/gul14/traits.h
@@ -1,29 +1,22 @@
 /**
  * \file    traits.h
  * \brief   Some metaprogramming traits for the General Utility Library.
- * \authors \ref contributors
+ * \authors \ref contributors, Michael Park
  * \date    Created on 20 August 2021
  *
- * \copyright Copyright 2021-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * Copyright 2015-2017 Michael Park (implementations of invoke, invoke_result,
+ * invoke_result_t, is_invocable, is_invocable_r), copyright 2021-2024 Deutsches
+ * Elektronen-Synchrotron (DESY), Hamburg (other implementations and modifications)
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 2.1 of the license, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See \ref license_boost_1_0 or http://boost.org/LICENSE_1_0.txt)
  */
 
 #ifndef GUL14_TRAITS_H_
 #define GUL14_TRAITS_H_
 
 #include <type_traits>
+#include <utility>
 
 #include "gul14/internal.h"
 
@@ -96,6 +89,212 @@ using remove_cvref_t = typename remove_cvref<T>::type;
  */
 template <typename...>
 using void_t = void;
+
+
+//
+// invoke & friends
+//
+#if __cplusplus >= 201703L
+
+using std::invoke;
+using std::invoke_result;
+using std::invoke_result_t;
+using std::is_invocable;
+using std::is_invocable_r;
+
+#else
+
+namespace detail_invoke {
+
+#define GUL14_RETURN(...) \
+  noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { return __VA_ARGS__; }
+
+template <typename T>
+struct is_reference_wrapper : std::false_type {};
+
+template <typename T>
+struct is_reference_wrapper<std::reference_wrapper<T>>
+    : std::true_type {};
+
+template <bool, int>
+struct Invoke;
+
+template <>
+struct Invoke<true /* pmf */, 0 /* is_base_of */> {
+    template <typename R, typename T, typename Arg, typename... Args>
+    inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+    GUL14_RETURN((std::forward<Arg>(arg).*pmf)(std::forward<Args>(args)...))
+};
+
+template <>
+struct Invoke<true /* pmf */, 1 /* is_reference_wrapper */> {
+    template <typename R, typename T, typename Arg, typename... Args>
+    inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+    GUL14_RETURN((std::forward<Arg>(arg).get().*pmf)(std::forward<Args>(args)...))
+};
+
+template <>
+struct Invoke<true /* pmf */, 2 /* otherwise */> {
+    template <typename R, typename T, typename Arg, typename... Args>
+    inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+    GUL14_RETURN(((*std::forward<Arg>(arg)).*pmf)(std::forward<Args>(args)...))
+};
+
+template <>
+struct Invoke<false /* pmo */, 0 /* is_base_of */> {
+    template <typename R, typename T, typename Arg>
+    inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+    GUL14_RETURN(std::forward<Arg>(arg).*pmo)
+};
+
+template <>
+struct Invoke<false /* pmo */, 1 /* is_reference_wrapper */> {
+    template <typename R, typename T, typename Arg>
+    inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+    GUL14_RETURN(std::forward<Arg>(arg).get().*pmo)
+};
+
+template <>
+struct Invoke<false /* pmo */, 2 /* otherwise */> {
+    template <typename R, typename T, typename Arg>
+    inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+        GUL14_RETURN((*std::forward<Arg>(arg)).*pmo)
+};
+
+template <typename R, typename T, typename Arg, typename... Args>
+inline constexpr auto invoke(R T::*f, Arg&& arg, Args&&... args)
+    GUL14_RETURN(
+        Invoke<std::is_function<R>::value,
+                (std::is_base_of<T, std::decay_t<Arg>>::value
+                    ? 0
+                    : is_reference_wrapper<std::decay_t<Arg>>::value
+                        ? 1
+                        : 2)>::invoke(f,
+                                        std::forward<Arg>(arg),
+                                        std::forward<Args>(args)...))
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#endif
+template <typename F, typename... Args>
+inline constexpr auto invoke(F &&f, Args &&... args)
+    GUL14_RETURN(std::forward<F>(f)(std::forward<Args>(args)...))
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#undef GUL14_RETURN
+
+} // namespace detail_invoke
+
+/**
+ * Invoke a callable object f with the given arguments.
+ *
+ * This is a backport of C++17's
+ * [std::invoke](https://en.cppreference.com/w/cpp/utility/functional/invoke).
+ *
+ * \since GUL version 2.11
+ */
+template <typename F, typename... Args>
+inline constexpr auto
+invoke(F&& f, Args&&... args) noexcept(
+    noexcept(detail_invoke::invoke(std::forward<F>(f), std::forward<Args>(args)...)))
+    -> decltype(detail_invoke::invoke(std::forward<F>(f), std::forward<Args>(args)...))
+{
+    return detail_invoke::invoke(std::forward<F>(f), std::forward<Args>(args)...);
+}
+
+
+namespace detail_invoke_result {
+
+template <typename T>
+struct identity { using type = T; };
+
+template <typename Void, typename, typename...>
+struct invoke_result {};
+
+template <typename F, typename... Args>
+struct invoke_result<void_t<decltype(invoke(
+                            std::declval<F>(), std::declval<Args>()...))>,
+                        F,
+                        Args...>
+    : identity<decltype(
+            invoke(std::declval<F>(), std::declval<Args>()...))> {};
+
+} // namespace detail_invoke_result
+
+/**
+ * A metafunction that computes the result of invoking a callable object of type F with
+ * the given arguments. The result is available in the member typedef \c type.
+ *
+ * This is a backport of C++17's
+ * [std::invoke_result](https://en.cppreference.com/w/cpp/types/result_of).
+ *
+ * \since GUL version 2.11
+ */
+template <typename F, typename... Args>
+using invoke_result = detail_invoke_result::invoke_result<void, F, Args...>;
+
+/**
+ * A shortcut for invoke_result<...>::type.
+ *
+ * This is a backport of C++17's
+ * [std::invoke_result_t](https://en.cppreference.com/w/cpp/types/result_of).
+ *
+ * \since GUL version 2.11
+ */
+template <typename F, typename... Args>
+using invoke_result_t = typename invoke_result<F, Args...>::type;
+
+
+namespace detail_invocable {
+
+template <typename Void, typename, typename...>
+struct is_invocable : std::false_type {};
+
+template <typename F, typename... Args>
+struct is_invocable<void_t<invoke_result_t<F, Args...>>, F, Args...>
+    : std::true_type {};
+
+template <typename Void, typename, typename, typename...>
+struct is_invocable_r : std::false_type {};
+
+template <typename R, typename F, typename... Args>
+struct is_invocable_r<void_t<invoke_result_t<F, Args...>>,
+                        R,
+                        F,
+                        Args...>
+    : std::is_convertible<invoke_result_t<F, Args...>, R> {};
+
+} // namespace detail_invocable
+
+/**
+ * A type trait that checks whether a callable object of type F can be invoked with the
+ * given arguments. The boolean result is available in the member \c value.
+ *
+ * This is a backport of C++17's
+ * [std::is_invocable](https://en.cppreference.com/w/cpp/types/is_invocable).
+ *
+ * \since GUL version 2.11
+ */
+template <typename F, typename... Args>
+using is_invocable = detail_invocable::is_invocable<void, F, Args...>;
+
+/**
+ * A type trait that checks whether a callable object of type F can be invoked with the
+ * given arguments and returns a result convertible to R. The boolean result is available
+ * in the member \c value.
+ *
+ * This is a backport of C++17's
+ * [std::is_invocable_r](https://en.cppreference.com/w/cpp/types/is_invocable).
+ *
+ * \since GUL version 2.11
+ */
+template <typename R, typename F, typename... Args>
+using is_invocable_r = detail_invocable::is_invocable_r<void, R, F, Args...>;
+
+#endif // __cplusplus < 201703L
 
 /// @}
 

--- a/include/gul14/variant.h
+++ b/include/gul14/variant.h
@@ -12,7 +12,8 @@
  * been removed because GUL14 does not support pre-C++14 compilers.
  *
  * \copyright
- * Copyright 2015-2017 Michael Park; 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * Copyright 2015-2017 Michael Park;
+ * 2023-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  * Distributed under the Boost Software License, Version 1.0.
  * (See \ref license_boost_1_0 or http://boost.org/LICENSE_1_0.txt)
  */


### PR DESCRIPTION
This PR extracts the definitions of the C++17 backports of
    
- invoke,
- invoke_result,
- invoke_result_t,
- is_invokable,
- is_invokable_r
    
from M. Park's variant header and makes them available in the public traits.h header in namespace gul14. The definitions are useful for GUL14 users in general, but we can also use them inside the library. This PR uses them to replace an ad-hoc implementation in our `expected` header, and they will be needed for the `ThreadPool` PR.