### PR TITLE
Feature is_invocable_v

### DIFF
--- a/include/gul14/traits.h
+++ b/include/gul14/traits.h
@@ -281,6 +281,21 @@ template <typename F, typename... Args>
 using is_invocable = detail_invocable::is_invocable<void, F, Args...>;
 
 /**
+ * Helper variable template for is_invocable<>::value.
+ *
+ * This is a backport of C++17's
+ * [std::is_invocable_v](https://en.cppreference.com/w/cpp/types/is_invocable).
+ *
+ * Inline variables are not possible in C++14 so this might produce more
+ * symbols than needed.
+ *
+ * \since GUL version 2.11
+ */
+template <typename F, typename... Args>
+constexpr bool is_invocable_v =
+    gul14::is_invocable<F, Args...>::value;
+
+/**
  * A type trait that checks whether a callable object of type F can be invoked with the
  * given arguments and returns a result convertible to R. The boolean result is available
  * in the member \c value.
@@ -292,6 +307,21 @@ using is_invocable = detail_invocable::is_invocable<void, F, Args...>;
  */
 template <typename R, typename F, typename... Args>
 using is_invocable_r = detail_invocable::is_invocable_r<void, R, F, Args...>;
+
+/**
+ * Helper variable template for is_invocable_r<>::value.
+ *
+ * This is a backport of C++17's
+ * [std::is_invocable_r_v](https://en.cppreference.com/w/cpp/types/is_invocable).
+ *
+ * Inline variables are not possible in C++14 so this might produce more
+ * symbols than needed.
+ *
+ * \since GUL version 2.11
+ */
+template <typename R, typename F, typename... Args>
+constexpr bool is_invocable_r_v =
+    gul14::is_invocable_r<R, F, Args...>::value;
 
 #endif // __cplusplus < 201703L
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -44,6 +44,7 @@ tests = [
     'test_tokenize.cc',
     'test_Trigger.cc',
     'test_trim.cc',
+    'test_traits.cc',
     'test_type_name.cc',
     'test_variant.cc',
 ]

--- a/tests/test_traits.cc
+++ b/tests/test_traits.cc
@@ -1,0 +1,39 @@
+/**
+ * \file   test_traits.cc
+ * \author \ref contributors
+ * \date   Created on February 12, 2024
+ * \brief  Unit tests for some of the traits.
+ *
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gul14/catch.h"
+#include "gul14/traits.h"
+
+using namespace std::literals;
+
+TEST_CASE("is_invocable()", "[traits]")
+{
+    auto x = 1;
+    REQUIRE(gul14::is_invocable<decltype(x)>::value == false);
+    auto y = []() {};
+    REQUIRE(gul14::is_invocable<decltype(y)>::value == true);
+    REQUIRE(gul14::is_invocable_r<void, decltype(y), int>::value == false);
+    auto z = [](int) -> float { return { }; };
+    REQUIRE(gul14::is_invocable_r<void, decltype(z), int>::value == false);
+    REQUIRE(gul14::is_invocable_r<float, decltype(z), double>::value == true);
+    REQUIRE(gul14::is_invocable_r<std::string, decltype(z), double>::value == false);
+}

--- a/tests/test_traits.cc
+++ b/tests/test_traits.cc
@@ -36,4 +36,10 @@ TEST_CASE("is_invocable()", "[traits]")
     REQUIRE(gul14::is_invocable_r<void, decltype(z), int>::value == false);
     REQUIRE(gul14::is_invocable_r<float, decltype(z), double>::value == true);
     REQUIRE(gul14::is_invocable_r<std::string, decltype(z), double>::value == false);
+
+    REQUIRE(gul14::is_invocable_v<decltype(y)> == true);
+    REQUIRE(gul14::is_invocable_v<decltype(y)> == true);
+    REQUIRE(gul14::is_invocable_v<void(*)()> == true);
+    REQUIRE(gul14::is_invocable_r_v<int, bool(*)(double), float> == true);
+    REQUIRE(gul14::is_invocable_r_v<float, std::string(*)(double), double> == false);
 }


### PR DESCRIPTION
**[why]**
We backported `is_invocable<>` but there you have to write
`is_invocable<>::value` all the time.

Same with `is_invocable_r<>`.

C++17 in fact also has the helper templates with the `_v` suffix.

**[how]**
Just add the helper template, but leave out the `inline` part.
That can result in multiple identical symbols in the resulting
executable, but apart from the space issue this is 100% safe.

The duplication is from the symbol name and a small bit of the data
itself (a boolean). Duplication happens once for each TU the template is
used in with a specific signature.

Here an example when we use the same

    REQUIRE(gul14::is_invocable_v<void(*)()> == true);

in two TUs (i.e. two `test_*.cc` files):

    $ nm -C build/tests/libgul-test | grep invoc
    00000000003b7614 r gul14::is_invocable_v<void (*)()>
    00000000003b7d5c r gul14::is_invocable_v<void (*)()>