### PR TITLE
Bugfix inaccurate powl

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -6,6 +6,7 @@ libgul_src = files([
     'escape.cc',
     'replace.cc',
     'string_util.cc',
+    'to_number.cc',
     'Trigger.cc',
     'trim.cc',
 ])

--- a/src/to_number.cc
+++ b/src/to_number.cc
@@ -1,0 +1,98 @@
+/**
+ * \file    to_number.cc
+ * \brief   Implementation of pow10().
+ * \authors \ref contributors
+ * \date    Created on 19 Februar 2024
+ *
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cfloat>
+
+#include "gul14/to_number.h"
+
+namespace gul14 {
+
+namespace detail {
+
+long double pow10(int exponent)
+{
+    // The preprocessor macros below just allow long double with
+    //
+    // - exponent maximum 511 (typical is 308) which is usually
+    //   the case when long double == double (the code needs at least
+    //   an allowed maximum of 256 for the constants)
+    //
+    // OR
+    //
+    // - exponent maximum 8191 (typical 4932) which is usually
+    //   the case for 80 bit 'extended precision' or 'float128'
+    //   long doubles (the code needs at least an allowed maximum
+    //   of 4096 for the constants)
+
+    static_assert(LDBL_MAX_10_EXP >= 4096 or LDBL_MAX_10_EXP < 512,
+        "Unsupported long double type");
+    static_assert(LDBL_MIN_10_EXP <= -4096 or LDBL_MIN_10_EXP > -512,
+        "Unsupported long double type");
+
+    constexpr const long double direct_powers_pos[] = {
+        1E0L, 1E1L, 1E2L, 1E3L, 1E4L, 1E5L, 1E6L, 1E7L,
+        1E8L, 1E9L, 1E10L, 1E11L, 1E12L, 1E13L, 1E14L, 1E15L
+    };
+    constexpr const long double direct_powers_neg[] = {
+        1E0L, 1E-1L, 1E-2L, 1E-3L, 1E-4L, 1E-5L, 1E-6L, 1E-7L,
+        1E-8L, 1E-9L, 1E-10L, 1E-11L, 1E-12L, 1E-13L, 1E-14L, 1E-15L
+    };
+    constexpr const long double binary_powers_pos[] = {
+        1E16L, 1E32L, 1E64L, 1E128L, 1E256L,
+#if LDBL_MAX_10_EXP >= 4096
+        1E512L, 1E1024L, 1E2048L, 1E4096L,
+#endif
+        std::numeric_limits<long double>::infinity()
+    };
+    constexpr const long double binary_powers_neg[] = {
+        1E-16L, 1E-32L, 1E-64L, 1E-128L, 1E-256L,
+#if LDBL_MIN_10_EXP <= -4096
+        1E-512L, 1E-1024L, 1E-2048L, 1E-4096L,
+#endif
+        0
+    };
+    static_assert(sizeof(binary_powers_pos) == sizeof(binary_powers_neg),
+        "Precalculated arrays need to have the same size");
+    constexpr auto binary_powers_last_index =
+        sizeof(binary_powers_pos) / sizeof(*binary_powers_pos) - 1;
+    const long double* direct_powers = direct_powers_pos;
+    const long double* binary_powers = binary_powers_pos;
+
+    if (exponent < 0) {
+        exponent = -exponent;
+        direct_powers = direct_powers_neg;
+        binary_powers = binary_powers_neg;
+    }
+    auto result = direct_powers[exponent & 0xF];
+    exponent >>= 4;
+    for (int exponent_bit = 0; exponent > 0; ++exponent_bit, exponent >>= 1) {
+        if (exponent_bit == binary_powers_last_index)
+            return binary_powers[exponent_bit];
+        if (exponent & 1)
+            result *= binary_powers[exponent_bit];
+    }
+    return result;
+}
+
+} // namespace detail
+
+} // namespace gul14

--- a/tests/test_to_number.cc
+++ b/tests/test_to_number.cc
@@ -4,7 +4,7 @@
  * \date   Created on July 19, 2019
  * \brief  Test suite for to_number().
  *
- * \copyright Copyright 2019 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2019, 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,7 +22,9 @@
 
 #include <array>
 #include <cmath>
+#include <cfloat>
 #include <iomanip>
+#include <limits>
 #include <random>
 #include <sstream>
 
@@ -44,6 +46,44 @@ struct TestConfig {
     bool static const random_includes_inf_nan{ false };
     unsigned static const number_of_random_tests{ 5'000 };
 };
+
+template <typename T>
+int error_in_ulp(T value, T reference)
+{
+    int offset = 0;
+    do {
+        if (value == reference) {
+            return offset;
+        }
+        if (value < reference) {
+            --offset;
+            value = std::nextafter(value, T{ +INFINITY });
+        } else {
+            ++offset;
+            value = std::nextafter(value, T{ -INFINITY });
+        }
+    } while (offset >= -1000 && offset <= 1000);
+    return offset;
+}
+
+TEMPLATE_TEST_CASE("test details: error_in_ulp()", "[to_number]",
+    float, double, long double)
+{
+    auto ref = TestType{ 1.01L };
+    auto value = ref;
+    constexpr auto try_distance{ 10 };
+
+    for (int i = try_distance; i != 0; --i)
+        value += std::numeric_limits<TestType>::epsilon();
+    REQUIRE(error_in_ulp(value, ref) == try_distance);
+    REQUIRE(error_in_ulp(ref, value) == -try_distance);
+    value = ref;
+
+    for (int i = try_distance; i != 0; --i)
+        value -= std::numeric_limits<TestType>::epsilon();
+    REQUIRE(error_in_ulp(value, ref) == -try_distance);
+    REQUIRE(error_in_ulp(ref, value) == try_distance);
+}
 
 TEST_CASE("to_number(): Integer types", "[to_number]")
 {
@@ -162,17 +202,7 @@ TEMPLATE_TEST_CASE("to_number(): Floating point types", "[to_number]", float, do
     REQUIRE(to_number<TestType>("na").has_value() == false);
     REQUIRE(to_number<TestType>("nana").has_value() == false);
     REQUIRE(to_number<TestType>("nan(").has_value() == false);
-#ifdef _MSC_VER
-#pragma warning( push )
-#pragma warning( disable: 4127 )
-#endif
-    if (sizeof(TestType) <= sizeof(double)) {
-        // Apple clang 8.0.0 strtod() fails to check this input for long double
-        REQUIRE(to_number<TestType>("nan(.)").has_value() == false);
-    }
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
+    REQUIRE(to_number<TestType>("nan(.)").has_value() == false);
 }
 
 TEMPLATE_TEST_CASE("to_number(): integer max() values round-trip", "[to_number]",
@@ -380,9 +410,10 @@ TEMPLATE_TEST_CASE("to_number(): Convert floating-point values with many leading
             "0000000000000000000000000000000000000000000000000");
     REQUIRE(gul14::within_ulp(test4.value(), TestType(0.1l), lenience) == true);
 
+    // higher lenience here:
     auto const test5 = to_number<TestType>("0.00000000000000000000000000000000000000000000000001"
             "e0000000000000000000000000000000000000000000000001");
-    REQUIRE(gul14::within_ulp(test5.value(), TestType(1.0e-49l), lenience) == true);
+    REQUIRE(gul14::within_ulp(test5.value(), TestType(1.0e-49l), lenience + 1) == true);
 }
 
 /* Disabled because doocsdev16's gcc has insufficient constexpr support (but works on
@@ -419,5 +450,94 @@ TEMPLATE_TEST_CASE("to_number(): Floating-point types, constexpr", "[to_number]"
     REQUIRE(a == TestType{ -42.2e1 });
 }
 */
+
+TEST_CASE("test pow10()", "[to_number]")
+{
+    // Allow one ULP off
+    // (except when we allow two ULPs; for very small numbers)
+    constexpr auto lenience{ 1 };
+
+    struct TestCase {
+        int exponent_;
+        long double reference_;
+        int lenience_;
+
+        int deviation() const {
+            return std::abs(error_in_ulp(gul14::detail::pow10(exponent_), reference_));
+        }
+    };
+
+    auto cases = std::vector<TestCase>{
+        {    0,    1E0L, lenience }, {    -0,    1E-0L, lenience },
+        {    1,    1E1L, lenience }, {    -1,    1E-1L, lenience },
+        {    2,    1E2L, lenience }, {    -2,    1E-2L, lenience },
+        {    3,    1E3L, lenience }, {    -3,    1E-3L, lenience },
+        {    4,    1E4L, lenience }, {    -4,    1E-4L, lenience },
+        {    5,    1E5L, lenience }, {    -5,    1E-5L, lenience },
+        {    6,    1E6L, lenience }, {    -6,    1E-6L, lenience },
+        {    7,    1E7L, lenience }, {    -7,    1E-7L, lenience },
+        {    8,    1E8L, lenience }, {    -8,    1E-8L, lenience },
+        {    9,    1E9L, lenience }, {    -9,    1E-9L, lenience },
+        {   10,   1E10L, lenience }, {   -10,   1E-10L, lenience },
+        {   11,   1E11L, lenience }, {   -11,   1E-11L, lenience },
+        {   12,   1E12L, lenience }, {   -12,   1E-12L, lenience },
+        {   13,   1E13L, lenience }, {   -13,   1E-13L, lenience },
+        {   14,   1E14L, lenience }, {   -14,   1E-14L, lenience },
+        {   15,   1E15L, lenience }, {   -15,   1E-15L, lenience },
+        {   16,   1E16L, lenience }, {   -16,   1E-16L, lenience },
+        {   17,   1E17L, lenience }, {   -17,   1E-17L, lenience },
+        {   18,   1E18L, lenience }, {   -18,   1E-18L, lenience },
+        {   19,   1E19L, lenience }, {   -19,   1E-19L, lenience },
+        {   20,   1E20L, lenience }, {   -20,   1E-20L, lenience },
+        {   21,   1E21L, lenience }, {   -21,   1E-21L, lenience },
+        {   22,   1E22L, lenience }, {   -22,   1E-22L, lenience },
+        {   23,   1E23L, lenience }, {   -23,   1E-23L, lenience },
+        {   24,   1E24L, lenience }, {   -24,   1E-24L, lenience },
+        {   25,   1E25L, lenience }, {   -25,   1E-25L, lenience },
+        {   26,   1E26L, lenience }, {   -26,   1E-26L, lenience },
+        {   27,   1E27L, lenience }, {   -27,   1E-27L, lenience },
+        {   28,   1E28L, lenience }, {   -28,   1E-28L, lenience },
+        {   29,   1E29L, lenience }, {   -29,   1E-29L, lenience },
+        {   30,   1E30L, lenience }, {   -30,   1E-30L, lenience },
+        {  137,  1E137L, lenience }, {  -137,  1E-137L, lenience },
+        {  267,  1E267L, lenience }, {  -267,  1E-267L, lenience },
+#if LDBL_MAX_10_EXP > 500
+        {  678,  1E678L, lenience },
+        { 1234, 1E1234L, lenience },
+        { 3333, 1E3333L, lenience },
+        { 4095, 1E4095L, lenience },
+        { 4351, 1E4351L, lenience },
+        { 4607, 1E4607L, lenience },
+        { 4876, 1E4876L, lenience },
+        { 4877, 1E4877L, lenience },
+        { 4878, 1E4878L, lenience },
+        { 4879, 1E4879L, lenience },
+        { 4932, 1E4932L, lenience },
+#endif
+#if LDBL_MIN_10_EXP < -500
+        {  -678,  1E-678L, lenience },
+        { -1234, 1E-1234L, lenience },
+        { -3333, 1E-3333L, lenience },
+        { -4095, 1E-4095L, lenience + 1 },
+        { -4351, 1E-4351L, lenience },
+        { -4607, 1E-4607L, lenience + 1 },
+        { -4876, 1E-4876L, lenience },
+        { -4877, 1E-4877L, lenience },
+        { -4878, 1E-4878L, lenience },
+        { -4879, 1E-4879L, lenience },
+        { -4932, 1E-4932L, lenience },
+#endif
+    };
+
+    for (auto const& c : cases)
+        REQUIRE(c.deviation() <= c.lenience_);
+
+    // Overflows...
+    REQUIRE(std::isinf(gul14::detail::pow10(5000)));
+    REQUIRE(std::isinf(gul14::detail::pow10(8192)));
+
+    REQUIRE(gul14::detail::pow10(-5000) == 0);
+    REQUIRE(gul14::detail::pow10(-8192) == 0);
+}
 
 // vi:ts=4:sw=4:sts=4:et


### PR DESCRIPTION
**[why]**
For `to_number<long double>()` to work we need a `std::powl()` that is
accurate - its errors directly influence our conversion output, usually
amplified.
In the past we just knew about Apple clang that had a problem with
`std::powl()` being off a bit, but now also Alpine has the same problem
via musl that it uses.

**[how]**
On parsing a string a possible number is expressed with scientific
notification, for example `123.4E5` which means 123.4 * (10^5).

The mantissa is converted to a normalized value as floating point
number, (1.234 in the example) and the exponent is corrected for the
shift of decimal places (5 becomes 7). So the example is transformed
to 1.234 * (10^7).

To calculate the exponent the call `pow(10, 7)` is used. Any inaccuracy
in the calculation directly influences the result. For very big (or
small) exponents musl is off by more than 1000 ULPs.

But in fact a much simpler function than `pow()` would be sufficient.
The base is always 10 and the exponent is always integer. Usually `pow()`
calculates the result with `log2()` and `exp()` under the hood.
But given the constraints we can get away with a much simpler approach.

The new function `pow10(integer)` uses a table of precalculated results
for the exponents -16 to 16. Values for the other (bigger/smaller)
exponents are calculated with the right to left binary exponentiation.
The table needed for the binary approach is reasonably small while
giving good enough accuracy. Despite the fact that several
multiplications are chained the result is usually still within 1 ULP
to the correct result, only exponents that have almost all bits set
(i.e. need a lot of multiplications (7 or more)) have an error
of 2 ULP.

As we now have an exact enough `pow()` substitude the platform specific
exceptions and fallback to `std::strtold()` (that needs allocations)
can be removed.

The code assumes that
* double is: IEEE 754 binary64 (11 bit exponent)
* long double is:
  * just the same as double or
  * IEEE 754 Intel extended precision (15 bit exponent) or the
        same representation padded (on ARM)

If long double has exponents with not exactly 11 or 15 bits the code
and/or tests can break (fail).

There is no additional correction step to get the error in ULP down;
but we never guaranteed a better conversion than 3 ULP off. That still
holds. With one test we need to allow 1 ULP error where before it was
0 ULPs.

(*) The assumption is that floating point literals are handled
correctly; rounded to the nearest representation = 0 ULP off of
the ideal result.

**[note]**
Here some examples of reported std::powl() accuracy:

Ubuntu 23.10 (GLIBC 2.38)

    powl(10, -4000) off by 0 ULP
    powl(10, -2000) off by 0 ULP
    powl(10, -1000) off by 0 ULP
    powl(10, -500) off by 0 ULP
    powl(10, -250) off by -1 ULP
    powl(10, -100) off by 1 ULP
    powl(10, -10) off by 0 ULP

Alipne 3.19.1 (musl 1.2.4)

    powl(10, -4000) off by 26 ULP
    powl(10, -2000) off by 11 ULP
    powl(10, -1000) off by 5 ULP
    powl(10, -500) off by 1 ULP
    powl(10, -250) off by 1 ULP
    powl(10, -100) off by 1 ULP
    powl(10, -10) off by 0 ULP

Sonoma 14.3 on M2 (libSystem 1336.61.1)

    powl(10, -250) off by 0 ULP
    powl(10, -100) off by 0 ULP
    powl(10, -10) off by 0 ULP

On Sonoma it seems double == long double.

Github MacOS CI machine (x86?) (libSystem 1319.0.0)

    powl(10, -4000) off by more than 1000 ULP
    powl(10, -2000) off by 830 ULP
    powl(10, -1000) off by 396 ULP
    powl(10, -500) off by 191 ULP
    powl(10, -250) off by 133 ULP
    powl(10, -100) off by 66 ULP
    powl(10, -10) off by 6 ULP

    which is unexpected as the double performance is better

    pow(10, -250) off by 0 ULP
    pow(10, -100) off by 0 ULP
    pow(10, -10) off by 0 ULP

**[note]**
Some useful links:

About floating point representations:
https://en.wikipedia.org/wiki/Double-precision_floating-point_format
https://en.wikipedia.org/wiki/Extended_precision

David M. Gay's strtod() (Expat) for example here:
https://portal.ampl.com/~dmg/netlib/fp/dtoa.c

Rick Regan's Exploring Binary blog, for example
https://www.exploringbinary.com/fast-path-decimal-to-floating-point-conversion/
https://www.exploringbinary.com/strtod-initial-decimal-to-floating-point-approximation/
https://www.exploringbinary.com/why-powers-of-ten-up-to-10-to-the-22-are-exact-as-doubles/

Fixes: #69