### PR TITLE
ThreadPool: Fixup: Export missing symbols

### DIFF
--- a/include/gul14/ThreadPool.h
+++ b/include/gul14/ThreadPool.h
@@ -44,6 +44,7 @@ class ThreadPool;
 
 namespace detail {
 
+GUL_EXPORT
 std::shared_ptr<ThreadPool> lock_pool_or_throw(std::weak_ptr<ThreadPool> pool);
 
 } // namespace detail
@@ -382,33 +383,42 @@ public:
      *
      * \returns the number of tasks that were removed.
      */
+    GUL_EXPORT
     std::size_t cancel_pending_tasks();
 
     /// Return the maximum number of pending tasks that can be queued.
+    GUL_EXPORT
     std::size_t capacity() const noexcept { return capacity_; }
 
     /// Return the number of pending tasks.
+    GUL_EXPORT
     std::size_t count_pending() const;
 
     /// Return the number of threads in the pool.
+    GUL_EXPORT
     std::size_t count_threads() const noexcept;
 
     /// Return a vector with the names of the tasks that are waiting to be executed.
+    GUL_EXPORT
     std::vector<std::string> get_pending_task_names() const;
 
     /// Return a vector with the names of the tasks that are currently running.
+    GUL_EXPORT
     std::vector<std::string> get_running_task_names() const;
 
     /// Determine whether the queue for pending tasks is full (at capacity).
+    GUL_EXPORT
     bool is_full() const noexcept;
 
     /**
      * Return true if the pool has neither pending tasks nor tasks that are currently
      * being executed.
      */
+    GUL_EXPORT
     bool is_idle() const;
 
     /// Determine whether the thread pool has been requested to shut down.
+    GUL_EXPORT
     bool is_shutdown_requested() const;
 
     /**
@@ -420,6 +430,7 @@ public:
      *
      * \returns a shared pointer to the created ThreadPool object.
      */
+    GUL_EXPORT
     static std::shared_ptr<ThreadPool> make_shared(
         std::size_t num_threads, std::size_t capacity = default_capacity);
 
@@ -535,6 +546,7 @@ private:
      * \returns true if a task was removed, false if no pending task with the given ID was
      *          found.
      */
+    GUL_EXPORT
     bool cancel_pending_task(TaskId task_id);
 
     /**
@@ -546,12 +558,14 @@ private:
      *     InternalTaskState::running if the task is currently being executed, or
      *     InternalTaskState::unknown if the thread pool has no knowledge of this task ID.
      */
+    GUL_EXPORT
     InternalTaskState get_task_state(TaskId task_id) const;
 
     /**
      * Determine whether the queue for pending tasks is full (internal non-locking
      * version).
      */
+    GUL_EXPORT
     bool is_full_i() const noexcept;
 
     /**

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -51,7 +51,7 @@ test('all',
     executable('libgul-test',
         tests + [ catch_main ],
         cpp_args : test_cpp_args,
-        dependencies : [ libgul_static_dep ],
+        dependencies : [ libgul_dep ],
     ),
     timeout : test_time
 )


### PR DESCRIPTION
**[why]**
Some symbols (functions) are not exported to the shared library. But they are accessed by templated functions, so the call to them is instantiated by user code and the user needs to have access to the functions. That is even then the case when private member functions are involved.

**[how]**
Add export specifier to needed functions. Some few functions seem (!) to have no need for export, so they are excluded from exporting right now.

Maybe we want to export all functions. That whole setup is quite a thicket and it is hard to follow which templated functions call which other templated functions and so in the end need exported basic functions.

Then do the tests again with the shared library.

Another possibility would be to
 - Avoid templated functions that call internals (haha)
 - Make the whole ThreadPool a template so that the now exported functions all would be instantiated by the users (wastes spaces)

**[note]**
Most functions are now exported but not all. Hope the tests instantiate all templates in a way that all needed functions are called at least once. On the other hand we could just make all functions exporty.

**[note]**
ThreadPool is **_BROKEN_** in the current GUL release because the symbols are missing. The tests should use what users will use to make sure it will work. As the tests did not work with the current shared libraries that is true for any user code.

Fixes: #83