### PR TITLE
Make ThreadPool resizable (i.e. change number of threads at runtime)

### DIFF
--- a/include/gul14/ThreadPool.h
+++ b/include/gul14/ThreadPool.h
@@ -244,7 +244,7 @@ public:
     constexpr static std::size_t max_capacity{ 10'000'000 };
 
     /// Maximum possible number of threads
-    constexpr static std::size_t max_threads{ 10'000 };
+    constexpr static std::size_t num_threads_max{ 10'000 };
 
     /**
      * Destruct the ThreadPool and join all threads.
@@ -328,7 +328,7 @@ public:
                 const auto needed_threads = running_task_ids_.size() + pending_tasks_.size();
                 if (needed_threads > num_threads and num_threads < max_threads_)
                 {
-                    threads_.emplace_back(Thread{ std::thread{ [this]() { perform_work(); } }, true} );
+                    threads_.emplace_back(Thread{ std::thread{ [this]() { perform_work(); } }, true } );
                 }
 
                 return handle;
@@ -514,7 +514,7 @@ private:
     };
 
     struct Thread {
-        std::thread t;
+        std::thread thread;
         bool running{ false };
     };
 
@@ -555,7 +555,7 @@ private:
      * \param capacity     Maximum number of pending tasks that can be queued
      *
      * \exception std::invalid_argument is thrown if the desired number of threads is
-     *            zero or greater than max_threads, or if the requested capacity is zero
+     *            zero or greater than num_threads_max, or if the requested capacity is zero
      *            or exceeds max_capacity.
      */
     ThreadPool(std::size_t num_threads, std::size_t capacity);

--- a/src/ThreadPool.cc
+++ b/src/ThreadPool.cc
@@ -62,6 +62,8 @@ ThreadPool::ThreadPool(std::size_t num_threads, std::size_t capacity)
         throw std::invalid_argument(cat("Illegal capacity for thread pool: ", capacity));
 
     threads_.reserve(num_threads);
+    while (threads_.size() < num_threads)
+        threads_.emplace_back(Thread{ std::thread{ [this]() { perform_work(); } }, true } );
 }
 
 ThreadPool::~ThreadPool()

--- a/tests/test_ThreadPool.cc
+++ b/tests/test_ThreadPool.cc
@@ -558,6 +558,27 @@ TEST_CASE("ThreadPool: Run 100 functions on 4 threads", "[ThreadPool]")
     pool.reset();
 }
 
+TEST_CASE("ThreadPool: Run 100 functions on 4 then 2 threads", "[ThreadPool]")
+{
+    auto pool = make_thread_pool(4);
+
+    for (int i = 1; i <= 100; ++i)
+    {
+        pool->add_task(
+            [i](ThreadPool& tp)
+            {
+                if (i == 50)
+                    tp.set_max_threads(2);
+                gul14::sleep(100us);
+            });
+    }
+
+    REQUIRE(pool->count_threads() == 4);
+    while (not pool->is_idle())
+        gul14::sleep(1ms);
+    REQUIRE(pool->count_threads() == 2);
+}
+
 TEST_CASE("ThreadPool: Capacity limit", "[ThreadPool]")
 {
     std::size_t max_jobs{ 10 };

--- a/tests/test_ThreadPool.cc
+++ b/tests/test_ThreadPool.cc
@@ -150,14 +150,14 @@ TEST_CASE("ThreadPool: Constructor", "[ThreadPool]")
     SECTION("Create a thread pool with 2 threads, default capacity")
     {
         auto pool = make_thread_pool(2);
-        REQUIRE(pool->count_threads() == 0);
+        REQUIRE(pool->count_threads() == 2);
         REQUIRE(pool->capacity() >= 10); // default capacity
     }
 
     SECTION("Create a thread pool with 1 thread, capacity 42")
     {
         auto pool = make_thread_pool(1, 42);
-        REQUIRE(pool->count_threads() == 0);
+        REQUIRE(pool->count_threads() == 1);
         REQUIRE(pool->capacity() == 42);
     }
 
@@ -172,7 +172,7 @@ TEST_CASE("ThreadPool: add_task() for functions without ThreadPool&",
 {
     auto pool = make_thread_pool(1);
 
-    REQUIRE(pool->count_threads() == 0);
+    REQUIRE(pool->count_threads() == 1);
 
     // Without start times
     std::atomic<bool> start{ false };
@@ -382,12 +382,14 @@ TEST_CASE("ThreadPool: count_pending()", "[ThreadPool]")
 
 TEST_CASE("ThreadPool: count_threads()", "[ThreadPool]")
 {
-    for (std::size_t i = 1; i <= 2; ++i)
+    for (std::size_t i = 2; i <= 3; ++i)
     {
         std::atomic<bool> stop{ false };
         // Make sure the pool is removed before the atomic variable goes out of scope by defining it after the atomic
-        auto pool = make_thread_pool(i);
-        REQUIRE(pool->count_threads() == 0);
+        auto pool = make_thread_pool(1);
+        REQUIRE(pool->count_threads() == 1);
+        pool->set_max_threads(i);
+        REQUIRE(pool->count_threads() == 1);
 
         pool->add_task([&stop]() { while (!stop) gul14::sleep(10us); }, "1");
         pool->add_task([&stop]() { while (!stop) gul14::sleep(10us); }, "2");

--- a/tests/test_ThreadPool.cc
+++ b/tests/test_ThreadPool.cc
@@ -385,7 +385,7 @@ TEST_CASE("ThreadPool: count_threads()", "[ThreadPool]")
     for (std::size_t i = 1; i <= 2; ++i)
     {
         std::atomic<bool> stop{ false };
-        // Make sure the pool is removed before the atomic variable go out of scope by defining it after the atomic
+        // Make sure the pool is removed before the atomic variable goes out of scope by defining it after the atomic
         auto pool = make_thread_pool(i);
         REQUIRE(pool->count_threads() == 0);
 


### PR DESCRIPTION
This is all in all rather lazy and does not allow to jump up and down in number of really running threads.
But I guess it is ok.

One could in principle make it less lazy if the number of threads increases (and try to schedule all pending Tasks).
Not sure if that is needed. I guess not - well, therefor I omitted it.

Maybe look at the diff commit by commit.

Fixes: #80 
