### PR TITLE
ThreadPool::TaskHandle: Add default constructor

### DIFF
--- a/include/gul14/ThreadPool.h
+++ b/include/gul14/ThreadPool.h
@@ -133,6 +133,15 @@ public:
     {
     public:
         /**
+         * Default-construct an invalid TaskHandle.
+         *
+         * This constructor creates an invalid TaskHandle which has no result and is not
+         * associated with a ThreadPool.
+         */
+        TaskHandle()
+        {}
+
+        /**
          * Construct a TaskHandle.
          *
          * This constructor is not meant to be used directly. Instead, TaskHandles are
@@ -228,7 +237,7 @@ public:
 
     private:
         std::future<T> future_;
-        TaskId id_;
+        TaskId id_{ 0 };
         std::weak_ptr<ThreadPool> pool_;
     };
 

--- a/tests/test_ThreadPool.cc
+++ b/tests/test_ThreadPool.cc
@@ -36,6 +36,15 @@ using namespace std::literals;
 // TaskHandle class
 //
 
+TEST_CASE("TaskHandle: Default constructor", "[ThreadPool]")
+{
+    ThreadPool::TaskHandle<void> handle;
+
+    REQUIRE_THROWS_AS(handle.get_result(), std::logic_error);
+    REQUIRE(handle.is_complete() == false);
+    REQUIRE_THROWS_AS(handle.get_state(), std::logic_error);
+}
+
 TEST_CASE("TaskHandle: cancel()", "[ThreadPool]")
 {
     auto pool = make_thread_pool(1);


### PR DESCRIPTION
Without a default constructor, it is almost impossible to store a `TaskHandle` in some user-defined data structure. This limits its usefulness dramatically. Hence, this PR adds a simple default constructor and a test to check that the default-constructed task handle does what one would expect (namely, nothing useful).