### PR TITLE
to_number: Allow basic usage of bool

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -144,6 +144,9 @@ namespace gul14 {
  *
  * \section changelog_2_x 2.x Versions
  *
+ * \subsection V2_12_0 Version 2.12.0
+ * - Add gul14::to_number<bool>
+ *
  * \subsection v2_11_2 Version 2.11.2
  *
  * - *Released with DOOCS 24.3.1*

--- a/include/gul14/to_number.h
+++ b/include/gul14/to_number.h
@@ -487,21 +487,21 @@ inline optional<NumberType> strtold_wrapper(gul14::string_view str) noexcept
  * \since GUL version 1.7 the NAN and INF floating point conversion
  */
 // Overload for unsigned integer types.
-template <typename NumberType,
-          std::enable_if_t<std::is_integral<NumberType>::value
-                           and std::is_unsigned<NumberType>::value
-                           and not std::is_same<NumberType, bool>::value, int> = 0>
-constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
+template <typename NumberType>
+constexpr inline std::enable_if_t<std::is_integral<NumberType>::value and
+                                  std::is_unsigned<NumberType>::value,
+                                  optional<NumberType>>
+to_number(gul14::string_view str) noexcept
 {
     return detail::to_unsigned_integer<NumberType>(str);
 }
 
 // Overload for signed integer types.
-template <typename NumberType,
-          std::enable_if_t<std::is_integral<NumberType>::value
-                           and std::is_signed<NumberType>::value
-                           and not std::is_same<NumberType, bool>::value, int> = 0>
-constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
+template <typename NumberType>
+constexpr inline std::enable_if_t<std::is_integral<NumberType>::value and
+                                  std::is_signed<NumberType>::value,
+                                  optional<NumberType>>
+to_number(gul14::string_view str) noexcept
 {
     if (str.empty())
         return nullopt;
@@ -530,9 +530,10 @@ constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
 }
 
 // Overload for floating-point types.
-template <typename NumberType,
-    std::enable_if_t<std::is_floating_point<NumberType>::value, int> = 0>
-constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
+template <typename NumberType>
+constexpr inline std::enable_if_t<std::is_floating_point<NumberType>::value,
+                                  optional<NumberType>>
+to_number(gul14::string_view str) noexcept
 {
     if (str.empty())
         return nullopt;
@@ -565,8 +566,8 @@ constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
     return detail::to_unsigned_float<NumberType>(str);
 }
 
-template<typename NumberType, std::enable_if_t<std::is_same<NumberType, bool>::value, int> = 0>
-constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
+template<>
+constexpr inline optional<bool> to_number<bool>(gul14::string_view str) noexcept
 {
     size_t pos{};
     bool value{};

--- a/include/gul14/to_number.h
+++ b/include/gul14/to_number.h
@@ -460,8 +460,13 @@ inline optional<NumberType> strtold_wrapper(gul14::string_view str) noexcept
  *   notation using a small or capital "e" ("12e5", "4.2e1", ".2e-4", "2.E5").
  * * Infinity expressions: (optional minus sign) INF or INFINITY ignoring case.
  * * Not-a-number expressions: (optional minus sign) NAN or NAN(char_sequence) ignoring case.
-     The char_sequence can only contain digits, Latin letters, and underscores.
-     The result is a quiet NaN floating-point value.
+ *   The char_sequence can only contain digits, Latin letters, and underscores.
+ *   The result is a quiet NaN floating-point value.
+ *
+ * <h5>Boolean type</h5>
+ * Recognizes only
+ * * "true" or "false" (case insensitive)
+ * * "1" or "0" (no additional leading zeros allowed)
  *
  * The behavior with surrounding whitespace is *undefined*, so
  * it should be removed before passing input to this function.
@@ -485,6 +490,7 @@ inline optional<NumberType> strtold_wrapper(gul14::string_view str) noexcept
  *
  * \since GUL version 1.6
  * \since GUL version 1.7 the NAN and INF floating point conversion
+ * \since GUL version 2.12 bool conversion
  */
 // Overload for unsigned integer types.
 template <typename NumberType>
@@ -566,24 +572,17 @@ to_number(gul14::string_view str) noexcept
     return detail::to_unsigned_float<NumberType>(str);
 }
 
+// Overload for bool
 template<>
 constexpr inline optional<bool> to_number<bool>(gul14::string_view str) noexcept
 {
-    size_t pos{};
-    bool value{};
-
-    for (; pos < str.length(); ++pos)
-    {
-        if (not std::isdigit(str[pos]))
-            break;
-
-        if (str[pos] != '0')
-            value = true;
+    if (str.length() == 1) {
+        if (str[0] == '1')
+            return true;
+        if (str[0] == '0')
+            return false;
+        return nullopt;
     }
-
-    if (pos == str.length())
-        return value;
-
     if (equals_nocase(str, "true"))
         return true;
 

--- a/include/gul14/to_number.h
+++ b/include/gul14/to_number.h
@@ -488,8 +488,9 @@ inline optional<NumberType> strtold_wrapper(gul14::string_view str) noexcept
  */
 // Overload for unsigned integer types.
 template <typename NumberType,
-          std::enable_if_t<std::is_integral<NumberType>::value &&
-                           std::is_unsigned<NumberType>::value, int> = 0>
+          std::enable_if_t<std::is_integral<NumberType>::value
+                           and std::is_unsigned<NumberType>::value
+                           and not std::is_same<NumberType, bool>::value, int> = 0>
 constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
 {
     return detail::to_unsigned_integer<NumberType>(str);
@@ -497,8 +498,9 @@ constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
 
 // Overload for signed integer types.
 template <typename NumberType,
-          std::enable_if_t<std::is_integral<NumberType>::value &&
-                           std::is_signed<NumberType>::value, int> = 0>
+          std::enable_if_t<std::is_integral<NumberType>::value
+                           and std::is_signed<NumberType>::value
+                           and not std::is_same<NumberType, bool>::value, int> = 0>
 constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
 {
     if (str.empty())
@@ -561,6 +563,20 @@ constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
     }
 
     return detail::to_unsigned_float<NumberType>(str);
+}
+
+template<typename NumberType, std::enable_if_t<std::is_same<NumberType, bool>::value, int> = 0>
+constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
+{
+    constexpr std::array<gul14::string_view const, 2> yes = { "1", "true" };
+    if (std::find(yes.cbegin(), yes.cend(), gul14::lowercase_ascii(str)) != yes.cend())
+            return { true };
+
+    constexpr std::array<gul14::string_view const, 2> no = { "0", "false" };
+    if (std::find(no.cbegin(), no.cend(), gul14::lowercase_ascii(str)) != no.cend())
+            return { false };
+
+    return {};
 }
 
 /// @}

--- a/include/gul14/to_number.h
+++ b/include/gul14/to_number.h
@@ -568,15 +568,28 @@ constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
 template<typename NumberType, std::enable_if_t<std::is_same<NumberType, bool>::value, int> = 0>
 constexpr inline optional<NumberType> to_number(gul14::string_view str) noexcept
 {
-    constexpr std::array<gul14::string_view const, 2> yes = { "1", "true" };
-    if (std::find(yes.cbegin(), yes.cend(), gul14::lowercase_ascii(str)) != yes.cend())
-            return { true };
+    size_t pos{};
+    bool value{};
 
-    constexpr std::array<gul14::string_view const, 2> no = { "0", "false" };
-    if (std::find(no.cbegin(), no.cend(), gul14::lowercase_ascii(str)) != no.cend())
-            return { false };
+    for (; pos < str.length(); ++pos)
+    {
+        if (not std::isdigit(str[pos]))
+            break;
 
-    return {};
+        if (str[pos] != '0')
+            value = true;
+    }
+
+    if (pos == str.length())
+        return value;
+
+    if (equals_nocase(str, "true"))
+        return true;
+
+    if (equals_nocase(str, "false"))
+        return false;
+
+    return nullopt;
 }
 
 /// @}

--- a/tests/test_to_number.cc
+++ b/tests/test_to_number.cc
@@ -88,9 +88,9 @@ TEMPLATE_TEST_CASE("test details: error_in_ulp()", "[to_number]",
 TEST_CASE("to_number(): Integer types", "[to_number]")
 {
     REQUIRE(to_number<bool>("0").value() == false);
-    REQUIRE(to_number<bool>("000").value() == false);
+    REQUIRE(to_number<bool>("000").has_value() == false);
     REQUIRE(to_number<bool>("1").value() == true);
-    REQUIRE(to_number<bool>("0002").value() == true);
+    REQUIRE(to_number<bool>("0002").has_value() == false);
     REQUIRE(to_number<bool>("TruE").value() == true);
     REQUIRE(to_number<bool>("falSe").value() == false);
     REQUIRE(to_number<bool>("TrueLies").has_value() == false);

--- a/tests/test_to_number.cc
+++ b/tests/test_to_number.cc
@@ -88,10 +88,14 @@ TEMPLATE_TEST_CASE("test details: error_in_ulp()", "[to_number]",
 TEST_CASE("to_number(): Integer types", "[to_number]")
 {
     REQUIRE(to_number<bool>("0").value() == false);
+    REQUIRE(to_number<bool>("000").value() == false);
     REQUIRE(to_number<bool>("1").value() == true);
-    REQUIRE(to_number<bool>("TRUE").value() == true);
-    REQUIRE(to_number<bool>("false").value() == false);
+    REQUIRE(to_number<bool>("0002").value() == true);
+    REQUIRE(to_number<bool>("TruE").value() == true);
+    REQUIRE(to_number<bool>("falSe").value() == false);
+    REQUIRE(to_number<bool>("TrueLies").has_value() == false);
     REQUIRE(to_number<bool>(" 1").has_value() == false);
+    REQUIRE(to_number<bool>("0123h").has_value() == false);
 
     REQUIRE(to_number<char>("0").value() == 0);
     REQUIRE(to_number<signed char>("127").value() == 127);

--- a/tests/test_to_number.cc
+++ b/tests/test_to_number.cc
@@ -87,6 +87,12 @@ TEMPLATE_TEST_CASE("test details: error_in_ulp()", "[to_number]",
 
 TEST_CASE("to_number(): Integer types", "[to_number]")
 {
+    REQUIRE(to_number<bool>("0").value() == false);
+    REQUIRE(to_number<bool>("1").value() == true);
+    REQUIRE(to_number<bool>("TRUE").value() == true);
+    REQUIRE(to_number<bool>("false").value() == false);
+    REQUIRE(to_number<bool>(" 1").has_value() == false);
+
     REQUIRE(to_number<char>("0").value() == 0);
     REQUIRE(to_number<signed char>("127").value() == 127);
     REQUIRE(to_number<signed char>("-128").value() == -128);


### PR DESCRIPTION
**Why**  
The DOOCS Serverlib uses `to_number` when resorting values in `D_array`. But it breaks if we wanna instantiate an array of booleans.

This commit will add basic support to allow `to_number` been used with `bool`.

**How**  
First make sure the other implementations wont trigger, since `bool` is _arithmetic_, _integral_ and _unsigned_. Then add a very simple implementation which allows only `0|1` and `true|false`. And to round things up, add some very basic tests.