### PR TITLE
SmallVector: Make destructor more robust

### DIFF
--- a/include/gul14/SmallVector.h
+++ b/include/gul14/SmallVector.h
@@ -1429,7 +1429,7 @@ private:
     /// Determine if this vector is using allocated external storage.
     bool is_storage_allocated() const noexcept
     {
-        return capacity_ > inner_capacity();
+        return data_ptr_ != internal_array_.data();
     }
 
     /**


### PR DESCRIPTION
**[why]**
When the library is compiled with heavy instrumentalization (e.g. gcov) in some cases we get this compiler warning:

```
include/gul14/SmallVector.h:426:13: warning: ‘void operator delete [](void*)’ called on unallocated object ‘v3’ [-Wfree-nonheap-object]
  426 |             delete[] data_ptr_;
      |             ^~~~~~~~~~~~~~~~~~
```

The problem is the detection if the thing that currently holds the data is allocated or not. At the moment the size (capacity) is used as indirect marker. It seems that this can go wrong.

**[how]**
Use instead the pointed to address directly. We know the address of the internal data-holding array, and when the current data is not THAT is must be allocated.

Fixes: #91

Reviewed-by: Soeren Grunewald <soeren.grunewald@desy.de>