### PR TITLE
join(): Document that string type must provide size()

### DIFF
--- a/include/gul14/join_split.h
+++ b/include/gul14/join_split.h
@@ -244,8 +244,8 @@ split_sv(string_view text, string_view delimiter,
  * \returns all strings glued together with the delimiter glue.
  *
  * \tparam Iterator  A forward iterator type that dereferences to a string type. The
- *                   string type must support concatenation with std::string using
- *                   operator+=.
+ *                   string type must provide a size() member function and must support
+ *                   concatenation with std::string using operator+=.
  *
  * \see
  * join(StringContainer, string_view) is a convenience overload for joining entire
@@ -304,8 +304,9 @@ join(Iterator begin, Iterator end, string_view glue)
  * \tparam StringContainer  A container type that holds strings, e.g.
  *                          std::vector<std::string> or std::list<gul14::string_view>.
  *                          The container must provide an STL-like forward iterator
- *                          interface. The string type must support concatenation with
- *                          std::string using operator+=.
+ *                          interface. The string type must provide a size() member
+ *                          function and must support concatenation with std::string using
+ *                          operator+=.
  *
  * \see
  * join(Iterator, Iterator, string_view) has a two-iterator interface,


### PR DESCRIPTION
We documented that the string type must provide an `operator+=(string&, T)`, but forgot that it must also provide a `size()` member. This PR adds that documentation.