### PR TITLE
SmallVector: Change the SizeType definition to avoid warnings

### DIFF
--- a/include/gul14/SmallVector.h
+++ b/include/gul14/SmallVector.h
@@ -274,7 +274,7 @@ public:
     /// \copydoc ValueType
     using value_type = ValueType;
     /// Unsigned integer type for indexing, number of elements, capacity
-    using SizeType = uint32_t;
+    using SizeType = size_t;
     /// \copydoc SizeType
     using size_type = SizeType;
     /// Signed integer type for the difference of two iterators

--- a/tests/test_SmallVector.cc
+++ b/tests/test_SmallVector.cc
@@ -1299,7 +1299,7 @@ TEST_CASE("SmallVector: insert(ConstIterator, std::initializer_list)", "[SmallVe
 TEMPLATE_TEST_CASE("SmallVector: max_size()", "[SmallVector]", int, double, std::string)
 {
     SmallVector<TestType, 1> vec;
-    REQUIRE(vec.max_size() == std::numeric_limits<uint32_t>::max());
+    REQUIRE(vec.max_size() == std::numeric_limits<size_t>::max());
     REQUIRE(vec.capacity() <= vec.max_size());
     REQUIRE(vec.size() <= vec.max_size());
 }


### PR DESCRIPTION
**Why**
If one does compile with `-Wconversion` enabled, one does get a lot of warnings caused be SmallVector.   
Especially if one does use STL functions like `std::distance` or `std::forward` etc...

**How**
Change the SizeType definition from `uint32_t` to `size_t`.