### PR TITLE
tools: Search for doxygen only if needed

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -59,6 +59,6 @@ if get_option('docs') and doxygen.found() and graphviz.found() and doxy_run.foun
 
 elif get_option('docs')
     message('Documentation requested but tools missing, \'doc\' target not generated')
-endif # option docs and have doxy_run (doxywrap)
+endif # option docs and have all tools incl doxy_run (doxywrap)
 
 # vi:ts=4:sw=4:sts=4:et:syn=conf

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -5,13 +5,15 @@ changelogger = find_program('changelogger', required : false)
 
 # This is used by the Doxygen generation stuff
 # doxygen is used by doxywrap; if we have both we are ready to rumble
-doxygen = find_program('doxygen', required : false)
-if get_option('docs') and doxygen.found()
-    graphviz = find_program('dot', required : false)
-    if graphviz.found()
-        doxy_run = find_program('doxywrap')
-    else
-        message('Hint: dot is usually a part of the graphviz package')
+if get_option('docs')
+    doxygen = find_program('doxygen', required : false)
+    if doxygen.found()
+        graphviz = find_program('dot', required : false)
+        if graphviz.found()
+            doxy_run = find_program('doxywrap')
+        else
+            message('Hint: dot is usually a part of the graphviz package')
+        endif
     endif
 endif
 


### PR DESCRIPTION
When you do not want to generate the documentation Meson still searches for Doxygen - but it will never be used.

**[why]**  
We search for the `doxygen` executable even if we will never use it because the documentation target is not wanted.

**[how]**  
Put the search for the executable one level deeper.