### PR TITLE
Allow mutable function objects in thread pool

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -144,8 +144,13 @@ namespace gul14 {
  *
  * \section changelog_2_x 2.x Versions
  *
+ * \subsection V2_12_1 Version 2.12.1
+ *
+ * - Allow mutable function objects in ThreadPool::add_task()
+ *
  * \subsection V2_12_0 Version 2.12.0
- * - *Released with DOOCS 24.10.0-24.10.2*
+ *
+ * - *Released with DOOCS 24.10.0–24.12.1*
  * - Add gul14::to_number<bool>
  *
  * \subsection v2_11_2 Version 2.11.2

--- a/include/gul14/ThreadPool.h
+++ b/include/gul14/ThreadPool.h
@@ -346,7 +346,7 @@ public:
     add_task(Function fct, TimePoint start_time = {}, std::string name = {})
     {
         return add_task(
-            [f = std::move(fct)](ThreadPool&) { return f(); },
+            [f = std::move(fct)](ThreadPool&) mutable { return f(); },
             start_time, std::move(name));
     }
 

--- a/include/gul14/ThreadPool.h
+++ b/include/gul14/ThreadPool.h
@@ -296,6 +296,9 @@ public:
      * // A task with a name
      * pool->add_task([]() { std::cout << "Task 4\n"; }, "Task 4");
      * \endcode
+     *
+     * \since GUL version 2.12.1, add_task() unconditionally accepts mutable function
+     *        objects
      */
     template <typename Function>
     TaskHandle<invoke_result_t<Function, ThreadPool&>>

--- a/tests/test_ThreadPool.cc
+++ b/tests/test_ThreadPool.cc
@@ -176,8 +176,7 @@ TEST_CASE("ThreadPool: Constructor", "[ThreadPool]")
     }
 }
 
-TEST_CASE("ThreadPool: add_task() for functions without ThreadPool&",
-    "[ThreadPool]")
+TEST_CASE("ThreadPool: add_task() for functions without ThreadPool&", "[ThreadPool]")
 {
     auto pool = make_thread_pool(1);
 
@@ -205,8 +204,11 @@ TEST_CASE("ThreadPool: add_task() for functions without ThreadPool&",
     std::atomic<int> last_job{ 0 };
 
     const auto now = std::chrono::system_clock::now();
+
+    // We make one lambda mutable here to ensure that we can actually enqueue mutable
+    // function objects.
     auto task1 = pool->add_task(
-        [&last_job]() { last_job = 1; }, now + 120s);
+        [&last_job]() mutable { last_job = 1; }, now + 120s);
     pool->add_task(
         [&last_job]() { last_job = 2; }, now + 2ms,
         "task 2 (usually runs second)");
@@ -280,8 +282,11 @@ TEST_CASE("ThreadPool: add_task(f(ThreadPool&, ...))", "[ThreadPool]")
     std::atomic<int> last_job{ 0 };
 
     const auto now = std::chrono::system_clock::now();
+
+    // We make one lambda mutable here to ensure that we can actually enqueue mutable
+    // function objects.
     auto task1 = pool->add_task(
-        [&last_job](ThreadPool&) { last_job = 1; }, now + 120s);
+        [&last_job](ThreadPool&) mutable { last_job = 1; }, now + 120s);
     pool->add_task(
         [&last_job](ThreadPool&) { last_job = 2; }, now + 2ms,
         "task 2 (usually runs second)");


### PR DESCRIPTION
Because of an oversight, one of the `ThreadPool::add_task()` overloads did not accept mutable function objects. This happened because internally a non-mutable wrapper lambda was created that was then in turn unable to call the original mutable function object. This PR modifies the unit tests to check for this and fixes the issue.