### PR TITLE
Bugfix/resolve conversion warning

### DIFF
--- a/include/gul14/to_number.h
+++ b/include/gul14/to_number.h
@@ -370,7 +370,7 @@ constexpr inline optional<NumberType> to_unsigned_float(gul14::string_view str) 
     if (not norm_val.has_value())
         return nullopt;
 
-    return detail::pow10(exponent) * *norm_val;
+    return static_cast<NumberType>(detail::pow10(exponent) * *norm_val);
 }
 
 /**

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -50,7 +50,7 @@ tests = [
 test('all',
     executable('libgul-test',
         tests + [ catch_main ],
-        cpp_args : test_cpp_args,
+        cpp_args : [ test_cpp_args, add_cpp_args ],
         dependencies : [ libgul_dep ],
     ),
     timeout : test_time

--- a/tests/test_ThreadPool.cc
+++ b/tests/test_ThreadPool.cc
@@ -614,14 +614,14 @@ TEST_CASE("ThreadPool: Tasks scheduling their own continuation", "[ThreadPool]")
     std::string str;
 
     pool->add_task(
-        [&mutex, &str](ThreadPool& pool)
+        [&mutex, &str](ThreadPool& p)
         {
             {
                 std::lock_guard<std::mutex> lock(mutex);
                 str += '1';
             }
 
-            pool.add_task(
+            p.add_task(
                 [&mutex, &str]()
                 {
                     {
@@ -630,7 +630,7 @@ TEST_CASE("ThreadPool: Tasks scheduling their own continuation", "[ThreadPool]")
                     }
                 });
 
-            pool.add_task(
+            p.add_task(
                 [&mutex, &str]()
                 {
                     {

--- a/tests/test_to_number.cc
+++ b/tests/test_to_number.cc
@@ -69,7 +69,7 @@ int error_in_ulp(T value, T reference)
 TEMPLATE_TEST_CASE("test details: error_in_ulp()", "[to_number]",
     float, double, long double)
 {
-    auto ref = TestType{ 1.01L };
+    auto ref = TestType{ 1.01f };
     auto value = ref;
     constexpr auto try_distance{ 10 };
 


### PR DESCRIPTION
With adding more warnings to the DOOCS server library, I notice some warnings, which are not seen when compiling libgul14. It turns out, that we don't compile the tests with warnings enabled.

So this MR, will enable the warnings for the tests as well. And then fix them one by one.