### PR TITLE
ThreadPool: Add get_thread_index()

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -144,6 +144,10 @@ namespace gul14 {
  *
  * \section changelog_2_x 2.x Versions
  *
+ * \subsection V2_13_0 Version 2.13.0
+ *
+ * - Add ThreadPool::get_thread_index()
+ *
  * \subsection V2_12_1 Version 2.12.1
  *
  * - Allow mutable function objects in ThreadPool::add_task()

--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -146,7 +146,7 @@ namespace gul14 {
  *
  * \subsection V2_13_0 Version 2.13.0
  *
- * - Add ThreadPool::get_thread_index()
+ * - Add ThreadPool::get_thread_id()
  *
  * \subsection V2_12_1 Version 2.12.1
  *
@@ -758,7 +758,7 @@ namespace gul14 {
  * tests. It bundles all of its functionality in a single header file. For convenience,
  * the GUL-internal version of this header can be accessed via:
  * \code
- * #include "gul14/catch.h"
+ * #include <catch2/catch_all.hpp>
  * // Your unit tests here
  * \endcode
  * Please refer to https://github.com/catchorg/Catch2/blob/master/docs/tutorial.md

--- a/include/gul14/ThreadPool.h
+++ b/include/gul14/ThreadPool.h
@@ -113,6 +113,9 @@ public:
     /// A unique identifier for a task.
     using TaskId = std::uint64_t;
 
+    /// A unique identifier for a thread in the pool in the range of [0, count_threads()).
+    using ThreadId = std::vector<std::thread>::size_type;
+
     /**
      * A handle for a task that has (or had) been enqueued on a ThreadPool.
      *
@@ -420,8 +423,9 @@ public:
     std::vector<std::string> get_running_task_names() const;
 
     /**
-     * If called from a worker thread, return the zero-based index of the thread in the
-     * pool (0 for the first thread, 1 for the second, and so on).
+     * Return the thread pool ID of the current thread.
+     *
+     * \returns a thread ID in the range [0, count_threads()).
      *
      * \exception std::runtime_error is thrown if this function is called from a thread
      *            that is not part of the pool.
@@ -429,7 +433,7 @@ public:
      * \since GUL version 2.13
      */
     GUL_EXPORT
-    std::size_t get_thread_index() const;
+    ThreadId get_thread_id() const;
 
     /// Determine whether the queue for pending tasks is full (at capacity).
     GUL_EXPORT
@@ -529,9 +533,9 @@ private:
     /**
      * For worker threads, this is the index of the thread in the threads_ vector.
      * For other threads, the value is meaningless and the variable is initialized to
-     * numeric_limits<size_t>::max().
+     * numeric_limits<ThreadId>::max().
      */
-    thread_local static std::size_t thread_index_;
+    thread_local static ThreadId thread_id_;
 
     /**
      * A condition variable used together with mutex_ to wake up a worker thread when a

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project('gul14', 'cpp',
         'cpp_std=c++14',
         'warning_level=3',
     ],
-    version : '2.12',
+    version : '2.13',
     meson_version : '>=0.49')
 
 # Enforce that the version number is according to specs

--- a/src/ThreadPool.cc
+++ b/src/ThreadPool.cc
@@ -153,12 +153,12 @@ ThreadPool::InternalTaskState ThreadPool::get_task_state(const TaskId task_id) c
     return InternalTaskState::unknown;
 }
 
-std::size_t ThreadPool::get_thread_index() const
+ThreadPool::ThreadId ThreadPool::get_thread_id() const
 {
-    if (thread_index_ == std::numeric_limits<std::size_t>::max())
+    if (thread_id_ == std::numeric_limits<ThreadId>::max())
         throw std::runtime_error("This thread is not part of the pool");
 
-    return thread_index_;
+    return thread_id_;
 }
 
 bool ThreadPool::is_full() const noexcept
@@ -191,7 +191,7 @@ std::shared_ptr<ThreadPool> ThreadPool::make_shared(
     return std::shared_ptr<ThreadPool>(new ThreadPool(num_threads, capacity));
 }
 
-void ThreadPool::perform_work(const std::size_t thread_index)
+void ThreadPool::perform_work(const ThreadPool::ThreadId thread_id)
 {
 #if defined(__APPLE__) || defined(__GNUC__)
     // On unixoid systems, we block a number of signals in the worker threads because we
@@ -212,8 +212,8 @@ void ThreadPool::perform_work(const std::size_t thread_index)
     pthread_sigmask(SIG_BLOCK, &mask, 0);
 #endif
 
-    // Assign thread-local thread index
-    thread_index_ = thread_index;
+    // Assign thread-local thread ID
+    thread_id_ = thread_id;
 
     std::unique_lock<std::mutex> lock(mutex_);
 
@@ -276,7 +276,7 @@ void ThreadPool::perform_work(const std::size_t thread_index)
     }
 }
 
-thread_local std::size_t
-ThreadPool::thread_index_{ std::numeric_limits<std::size_t>::max() };
+thread_local ThreadPool::ThreadId
+ThreadPool::thread_id_{ std::numeric_limits<ThreadPool::ThreadId>::max() };
 
 } // namespace gul14

--- a/tests/test_ThreadPool.cc
+++ b/tests/test_ThreadPool.cc
@@ -452,17 +452,17 @@ TEST_CASE("ThreadPool: get_running_task_names()", "[ThreadPool]")
     pool.reset();
 }
 
-TEST_CASE("ThreadPool: get_thread_index()", "[ThreadPool]")
+TEST_CASE("ThreadPool: get_thread_id()", "[ThreadPool]")
 {
-    std::array<std::atomic<std::size_t>, 2> indices;
+    std::array<std::atomic<ThreadPool::ThreadId>, 2> indices;
     Trigger trigger;
 
     auto pool = make_thread_pool(2);
 
     pool->add_task(
-        [&](ThreadPool& p) { trigger.wait(); indices[0] = p.get_thread_index(); });
+        [&](ThreadPool& p) { trigger.wait(); indices[0] = p.get_thread_id(); });
     pool->add_task(
-        [&](ThreadPool& p) { trigger.wait(); indices[1] = p.get_thread_index(); });
+        [&](ThreadPool& p) { trigger.wait(); indices[1] = p.get_thread_id(); });
 
     while (pool->count_pending() > 0)
         gul14::sleep(1ms);
@@ -470,7 +470,7 @@ TEST_CASE("ThreadPool: get_thread_index()", "[ThreadPool]")
     trigger = true;
 
     // From a non-worker thread, the function must throw.
-    REQUIRE_THROWS_AS(pool->get_thread_index(), std::runtime_error);
+    REQUIRE_THROWS_AS(pool->get_thread_id(), std::runtime_error);
 
     pool.reset();
 


### PR DESCRIPTION
# [why]
There are use cases in which it is beneficial to know on which of the *N* pool threads a function gets executed. Sascha recently came up with one such case for the new clientlib NameService.
    
# [how]
Store a thread-local thread index when launching the threads. Return this index when called from a worker thread. For other threads, the thread-local index gets initialized to the maximum value of size_t; if this value is found, get_thread_index() throws an exception.