### PR TITLE
Enable new NRVO warning

### DIFF
--- a/src/escape.cc
+++ b/src/escape.cc
@@ -83,12 +83,13 @@ std::string unescape(string_view in)
     auto rit  = std::regex_iterator<string_view::const_iterator>{ in.cbegin(), in.cend(), re };
     auto const rend = std::regex_iterator<string_view::const_iterator>{ };
     auto last = decltype(*rit){ };
-
-    if (rit == rend)
-        return std::string{ in };
-
     auto unescaped = ""s;
     unescaped.reserve(in.length());
+
+    if (rit == rend) {
+        unescaped.assign(in.data(), in.size());
+        return unescaped;
+    }
 
     for (; rit != rend; ++rit) {
         last = *rit;

--- a/src/meson.build
+++ b/src/meson.build
@@ -99,6 +99,9 @@ endif
 if meson.get_compiler('cpp').has_argument('-Wconversion') # msvc doesnt have
     add_cpp_args += [ '-Wconversion' ]
 endif
+if meson.get_compiler('cpp').has_argument('-Wnrvo') # msvc: included in permissive-
+    add_cpp_args += [ '-Wnrvo' ]
+endif
 
 deps = dependency('threads')
 

--- a/src/replace.cc
+++ b/src/replace.cc
@@ -28,11 +28,12 @@ namespace gul14 {
 
 std::string replace(string_view haystack, string_view needle, string_view hammer)
 {
-    if (needle.empty())
-        return std::string(haystack);
-
     auto result = ""s;
     result.reserve(haystack.length());
+    if (needle.empty()) {
+        result.assign(haystack.data(), haystack.length());
+        return result;
+    }
 
     std::size_t pos = 0;
     std::size_t last_pos = 0;


### PR DESCRIPTION
[why]
While RVO is guaranteed and we will get warnings about pessimizations the c++17 new optional NRVO is warned on only on request (except on mcvc).

To get optimal code we of course want to benefit from NRVO optimizations.