### PR TITLE
Fix compilation with GCC 15.x.y

### DIFF
--- a/include/gul14/SmallVector.h
+++ b/include/gul14/SmallVector.h
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <initializer_list>
 #include <iterator>
 #include <limits>


### PR DESCRIPTION
[Why]
The compilation with GCC 15 fails with:
```
In file included from tests/incl_SmallVector.cc:23:
include/gul14/SmallVector.h:277:22: error: ‘uint32_t’ does not name a type [-Wtemplate-body]
  277 |     using SizeType = uint32_t;
      |                      ^~~~~~~~
include/gul14/SmallVector.h:37:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include  <stdint>’
   36 | #include "gul14/cat.h"
  +++ |+#include <cstdint>
   37 |
```