### PR TITLE
Resolve compiler warnings emited by clang

### DIFF
--- a/include/gul14/SlidingBuffer.h
+++ b/include/gul14/SlidingBuffer.h
@@ -467,10 +467,10 @@ public:
      */
     auto back() const noexcept -> const_reference
     {
-        if (idx_end_ == 0)
-            return storage_[capacity() - 1];
+        if (idx_end_ == 0u)
+            return storage_[capacity() - 1u];
         else
-            return storage_[idx_end_ - 1];
+            return storage_[idx_end_ - 1u];
     }
 
     /**
@@ -667,7 +667,7 @@ public:
          * \param buff Reference to the SlidingBuffer the iterator points into.
          * \param num  Index of the element the iterator points to.
          */
-        explicit SlidingBufferIterator(BufferPointer buff, size_type num = 0) noexcept
+        explicit SlidingBufferIterator(BufferPointer buff, size_type num = 0u) noexcept
             : position_{ num }
             , buffer_{ buff }
         {
@@ -746,7 +746,7 @@ public:
         operator-(const SlidingBufferIterator &lhs, const SlidingBufferIterator &rhs) noexcept
         -> difference_type
         {
-            return lhs.position_ - rhs.position_;
+            return static_cast<difference_type>(lhs.position_ - rhs.position_);
         }
 
         /// Access element pointed to by the iterator
@@ -981,10 +981,10 @@ protected:
 
         //////
         // Vanishing
-        if (new_capacity == 0) {
-            storage_.resize(0);
-            idx_begin_ = 0;
-            idx_end_ = 0;
+        if (new_capacity == 0u) {
+            storage_.resize(0u);
+            idx_begin_ = 0u;
+            idx_end_ = 0u;
             full_ = false;
             return;
         }
@@ -996,7 +996,7 @@ protected:
             // Make SlidingBuffer indices equal to those of the underlying container
             std::rotate(storage_.begin(), storage_.begin() + idx_begin_, storage_.end());
             storage_.resize(new_capacity);
-            idx_begin_ = 0;
+            idx_begin_ = 0u;
             idx_end_ = old_size;
             full_ = false;
             return;
@@ -1008,7 +1008,7 @@ protected:
             // All data fits into new capacity, just move it there
             std::rotate(storage_.begin(), storage_.begin() + idx_begin_, storage_.end());
             storage_.resize(new_capacity);
-            idx_begin_ = 0;
+            idx_begin_ = 0u;
             idx_end_ = old_size;
             full_ = false;
         }
@@ -1020,8 +1020,8 @@ protected:
             std::rotate(storage_.begin(), storage_.begin() + new_front, storage_.end());
             storage_.resize(new_capacity);
             full_ = true;
-            idx_begin_ = 0;
-            idx_end_ = 0;
+            idx_begin_ = 0u;
+            idx_end_ = 0u;
         }
     }
 };
@@ -1120,7 +1120,7 @@ public:
      */
     auto begin() noexcept -> iterator
     {
-        if (not full_ and (idx_end_ == 0 or idx_end_ >= idx_begin_))
+        if (not full_ and (idx_end_ == 0u or idx_end_ >= idx_begin_))
             return storage_.begin() + idx_begin_;
 
         return storage_.begin();
@@ -1140,7 +1140,7 @@ public:
      */
     auto cbegin() const noexcept -> const_iterator
     {
-        if (not full_ and (idx_end_ == 0 or idx_end_ >= idx_begin_))
+        if (not full_ and (idx_end_ == 0u or idx_end_ >= idx_begin_))
             return storage_.cbegin() + idx_begin_;
 
         return storage_.cbegin();
@@ -1165,7 +1165,7 @@ public:
      */
     auto end() noexcept -> iterator
     {
-        if (full_ or idx_begin_ != 0)
+        if (full_ or idx_begin_ != 0u)
             return storage_.end();
 
         return storage_.begin() + idx_end_;
@@ -1185,7 +1185,7 @@ public:
      */
     auto cend() const noexcept -> const_iterator
     {
-        if (full_ or idx_begin_ != 0)
+        if (full_ or idx_begin_ != 0u)
             return storage_.cend();
 
         return storage_.cbegin() + idx_end_;
@@ -1278,8 +1278,8 @@ public:
             and (new_capacity > 0)
             and (new_capacity != old_capacity)
             and (not full_)
-            and (idx_end_ == 0)
-            and (idx_begin_ != 0);
+            and (idx_end_ == 0u)
+            and (idx_begin_ != 0u);
 
         if (not right_align)
             return this->change_capacity(new_capacity, shrink_behavior);

--- a/include/gul14/SlidingBuffer.h
+++ b/include/gul14/SlidingBuffer.h
@@ -691,7 +691,7 @@ public:
         /// Increase iterator by a given number of positions.
         auto operator+=(difference_type d) noexcept -> SlidingBufferIterator&
         {
-            position_ += d;
+            position_ += static_cast<size_type>(d);
             return *this;
         }
 
@@ -700,7 +700,7 @@ public:
         operator+(const SlidingBufferIterator &it, difference_type d) noexcept
         -> SlidingBufferIterator
         {
-            return SlidingBufferIterator{ it.buffer_, it.position_ + d };
+            return SlidingBufferIterator{ it.buffer_, it.position_ + static_cast<size_type>(d) };
         }
 
         /// Add an integer and an iterator.
@@ -708,7 +708,7 @@ public:
         operator+(difference_type d, const SlidingBufferIterator &it) noexcept
         -> SlidingBufferIterator
         {
-            return SlidingBufferIterator{ it.buffer_, it.position_ + d };
+            return SlidingBufferIterator{ it.buffer_, it.position_ + static_cast<size_type>(d) };
         }
 
         /// Pre-decrement iterator by one position
@@ -729,7 +729,7 @@ public:
         /// Decrease iterator by a given number of positions.
         auto operator-=(difference_type d) noexcept -> SlidingBufferIterator&
         {
-            position_ -= d;
+            position_ -= static_cast<size_type>(d);
             return *this;
         }
 
@@ -738,7 +738,7 @@ public:
         operator-(const SlidingBufferIterator &it, difference_type d) noexcept
         -> SlidingBufferIterator
         {
-            return SlidingBufferIterator{ it.buffer_, it.position_ - d };
+            return SlidingBufferIterator{ it.buffer_, it.position_ - static_cast<size_type>(d) };
         }
 
         /// Subtract two iterators.
@@ -994,7 +994,7 @@ protected:
         // Growing
         if (new_capacity > old_capacity) {
             // Make SlidingBuffer indices equal to those of the underlying container
-            std::rotate(storage_.begin(), storage_.begin() + idx_begin_, storage_.end());
+            std::rotate(storage_.begin(), storage_.begin() + static_cast<difference_type>(idx_begin_), storage_.end());
             storage_.resize(new_capacity);
             idx_begin_ = 0u;
             idx_end_ = old_size;
@@ -1006,7 +1006,7 @@ protected:
         // Shrinking
         if (old_size < new_capacity) {
             // All data fits into new capacity, just move it there
-            std::rotate(storage_.begin(), storage_.begin() + idx_begin_, storage_.end());
+            std::rotate(storage_.begin(), storage_.begin() + static_cast<difference_type>(idx_begin_), storage_.end());
             storage_.resize(new_capacity);
             idx_begin_ = 0u;
             idx_end_ = old_size;
@@ -1017,7 +1017,7 @@ protected:
             if (shrink_behavior == ShrinkBehavior::keep_back_elements)
                 new_front = (idx_end_ + old_capacity - new_capacity) % old_capacity;
 
-            std::rotate(storage_.begin(), storage_.begin() + new_front, storage_.end());
+            std::rotate(storage_.begin(), storage_.begin() + static_cast<difference_type>(new_front), storage_.end());
             storage_.resize(new_capacity);
             full_ = true;
             idx_begin_ = 0u;
@@ -1121,7 +1121,7 @@ public:
     auto begin() noexcept -> iterator
     {
         if (not full_ and (idx_end_ == 0u or idx_end_ >= idx_begin_))
-            return storage_.begin() + idx_begin_;
+            return storage_.begin() + static_cast<difference_type>(idx_begin_);
 
         return storage_.begin();
     }
@@ -1141,7 +1141,7 @@ public:
     auto cbegin() const noexcept -> const_iterator
     {
         if (not full_ and (idx_end_ == 0u or idx_end_ >= idx_begin_))
-            return storage_.cbegin() + idx_begin_;
+            return storage_.cbegin() + static_cast<difference_type>(idx_begin_);
 
         return storage_.cbegin();
     }
@@ -1168,7 +1168,7 @@ public:
         if (full_ or idx_begin_ != 0u)
             return storage_.end();
 
-        return storage_.begin() + idx_end_;
+        return storage_.begin() + static_cast<difference_type>(idx_end_);
     }
 
     /// \overload
@@ -1188,7 +1188,7 @@ public:
         if (full_ or idx_begin_ != 0u)
             return storage_.cend();
 
-        return storage_.cbegin() + idx_end_;
+        return storage_.cbegin() + static_cast<difference_type>(idx_end_);
     }
 
     /**
@@ -1288,8 +1288,8 @@ public:
         // Growing
         if (new_capacity > old_capacity) {
             storage_.resize(new_capacity);
-            std::move_backward(storage_.begin() + idx_begin_,
-                               storage_.begin() + old_capacity, storage_.end());
+            std::move_backward(storage_.begin() + static_cast<difference_type>(idx_begin_),
+                               storage_.begin() + static_cast<difference_type>(old_capacity), storage_.end());
             idx_begin_ += new_capacity - old_capacity;
             return;
         }
@@ -1298,7 +1298,7 @@ public:
         // Shrinking
         full_ = (this->size() >= new_capacity);
         auto const required_shift = std::min(old_capacity - new_capacity, idx_begin_);
-        std::rotate(storage_.begin(), storage_.begin() + required_shift, storage_.end());
+        std::rotate(storage_.begin(), storage_.begin() + static_cast<difference_type>(required_shift), storage_.end());
         idx_begin_ -= required_shift;
         storage_.resize(new_capacity);
     }

--- a/include/gul14/date.h
+++ b/include/gul14/date.h
@@ -909,8 +909,8 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_weekday_last&
 inline namespace literals
 {
 
-constexpr gul14::date::day  operator "" _d(unsigned long long d) noexcept;
-constexpr gul14::date::year operator "" _y(unsigned long long y) noexcept;
+constexpr gul14::date::day  operator ""_d(unsigned long long d) noexcept;
+constexpr gul14::date::year operator ""_y(unsigned long long y) noexcept;
 
 }  // inline namespace literals
 #endif // !defined(_MSC_VER) || (_MSC_VER >= 1900)
@@ -1810,14 +1810,14 @@ inline namespace literals
 
 constexpr inline
 gul14::date::day
-operator "" _d(unsigned long long d) noexcept
+operator ""_d(unsigned long long d) noexcept
 {
     return gul14::date::day{static_cast<unsigned>(d)};
 }
 
 constexpr inline
 gul14::date::year
-operator "" _y(unsigned long long y) noexcept
+operator ""_y(unsigned long long y) noexcept
 {
     return gul14::date::year(static_cast<int>(y));
 }

--- a/include/gul14/optional.h
+++ b/include/gul14/optional.h
@@ -82,7 +82,7 @@ inline constexpr typename std::remove_reference<T>::type&& constexpr_move(T&& t)
 #if defined NDEBUG
 #define GUL_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) (EXPR)
 #else
-#define GUL_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) ((CHECK) ? (EXPR) : ([]{assert(!#CHECK);}(), (EXPR)))
+#define GUL_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) ((CHECK) ? (EXPR) : ([]{assert((void(#CHECK), false));}(), (EXPR)))
 #endif
 
 

--- a/include/gul14/span.h
+++ b/include/gul14/span.h
@@ -215,7 +215,7 @@ public:
 
     /// See [std::span](https://en.cppreference.com/w/cpp/container/span).
     constexpr span(pointer first_elem, pointer last_elem)
-        : storage_(first_elem, last_elem - first_elem)
+        : storage_(first_elem, static_cast<std::size_t>(last_elem - first_elem))
     {}
 
     /// See [std::span](https://en.cppreference.com/w/cpp/container/span).

--- a/include/gul14/string_util.h
+++ b/include/gul14/string_util.h
@@ -151,7 +151,7 @@ template <typename Iterator>
 inline std::string
 hex_string(Iterator begin, Iterator end, string_view separator = "")
 {
-    const std::size_t n = std::distance(begin, end);
+    const std::size_t n = static_cast<std::size_t>(std::distance(begin, end));
 
     std::string result;
 

--- a/include/gul14/string_view.h
+++ b/include/gul14/string_view.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <cstring>
 #include <iosfwd>
+#include <ios>
 
 #include "gul14/internal.h"
 
@@ -571,9 +572,9 @@ inline void sv_insert_fill_chars(std::basic_ostream<charT, traits>& os, std::siz
     charT fill_chars[chunk_size];
     std::fill_n(fill_chars, static_cast< std::size_t >(chunk_size), os.fill());
     for (; n >= chunk_size && os.good(); n -= chunk_size)
-        os.write(fill_chars, static_cast< std::size_t >(chunk_size));
+        os.write(fill_chars, static_cast< std::streamsize >(chunk_size));
     if (n > 0 && os.good())
-        os.write(fill_chars, n);
+        os.write(fill_chars, static_cast< std::streamsize >(n));
 }
 
 template<class charT, class traits>
@@ -585,10 +586,10 @@ void sv_insert_aligned(std::basic_ostream<charT, typename char_traits<charT>::ba
     if (!align_left) {
         detail::sv_insert_fill_chars(os, alignment_size);
         if (os.good())
-            os.write(str.data(), size);
+            os.write(str.data(), static_cast< std::streamsize >(size));
     }
     else {
-        os.write(str.data(), size);
+        os.write(str.data(), static_cast< std::streamsize >(size));
         if (os.good())
             detail::sv_insert_fill_chars(os, alignment_size);
     }
@@ -605,7 +606,7 @@ operator<<(std::basic_ostream<charT, typename char_traits<charT>::base_traits>& 
         const std::size_t size = str.size();
         const std::size_t w = static_cast< std::size_t >(os.width());
         if (w <= size)
-            os.write(str.data(), size);
+            os.write(str.data(), static_cast< std::streamsize >(size));
         else
             detail::sv_insert_aligned(os, str);
         os.width(0);

--- a/tests/test_SlidingBuffer.cc
+++ b/tests/test_SlidingBuffer.cc
@@ -192,6 +192,15 @@ void do_dumping_tests(T& buff)
                 "141.4  131.3  121.2  111.1  101  90.9  80.8  70.7  60.6  50.5"));
 }
 
+template <typename ValueType, size_t ElementCount>
+auto create_buffer() -> SlidingBuffer<ValueType, ElementCount>
+{
+    SlidingBuffer<ValueType, ElementCount> buf;
+    for (auto i = 0u; i != ElementCount; ++i)
+        buf.push_back(static_cast<ValueType>(i));
+    return buf;
+}
+
 TEST_CASE("SlidingBuffer test", "[SlidingBuffer]")
 {
     SECTION("queueing tests") {
@@ -231,7 +240,7 @@ TEST_CASE("SlidingBuffer test", "[SlidingBuffer]")
         auto it12 = buff1.begin();
         decltype(it12) it{ it12 }; // copy ctor
         auto end = buff1.end();
-        auto i = 0;
+        auto i = 0u;
         for (; it != end; ++it, ++i) {
             auto ref = buff1.at(i).val;
             REQUIRE(buff1[i].val == ref);
@@ -250,7 +259,7 @@ TEST_CASE("SlidingBuffer test", "[SlidingBuffer]")
         }
         REQUIRE(i == 10);
 
-        auto j = 0;
+        auto j = 0u;
         for (auto const& e : buff1) {
             REQUIRE(e.val == buff1[j++].val);
         }
@@ -897,7 +906,7 @@ TEST_CASE("SlidingBufferExposed test", "[SlidingBuffer]")
         auto it12 = buff1.begin();
         decltype(it12) it{ it12 }; // copy ctor
         auto end = buff1.end();
-        auto i = 0;
+        auto i = 0u;
         auto iterator_data = std::vector<double>{ };
         for (; it != end; ++it, ++i) {
             auto ref = (*it).val;
@@ -906,7 +915,7 @@ TEST_CASE("SlidingBufferExposed test", "[SlidingBuffer]")
         }
         std::sort(iterator_data.begin(), iterator_data.end());
 
-        REQUIRE(i == 10);
+        REQUIRE(i == 10u);
         auto index_data = std::vector<double>{ };
         while (i--) {
             auto ref = buff1.at(i).val;
@@ -919,13 +928,13 @@ TEST_CASE("SlidingBufferExposed test", "[SlidingBuffer]")
         auto it2 = buff1.rbegin();
         auto end2 = buff1.rend();
         end2 = buff1.rend();
-        i = 0;
+        i = 0u;
         auto iterator2_data = std::vector<double>{ };
         for (; it2 != end2; ++it2, ++i) {
             iterator2_data.push_back((*it2).val);
         }
         std::sort(iterator2_data.begin(), iterator2_data.end());
-        REQUIRE(i == 10);
+        REQUIRE(i == 10u);
         REQUIRE(index_data == iterator2_data);
     }
 }
@@ -1338,9 +1347,7 @@ TEST_CASE("SlidingBufferExposed: Shrinking behavior", "[SlidingBuffer]")
 
 TEST_CASE("SlidingBufferIterator: LegacyIterator requirements", "[SlidingBufferIterator]")
 {
-    SlidingBuffer<int, 10> buf;
-    for (auto i = 0u; i < buf.capacity(); i++)
-        buf.push_back(i);
+    auto buf = create_buffer<int, 10>();
 
     SECTION("prefix operator++ and dereferencing")
     {
@@ -1356,9 +1363,7 @@ TEST_CASE("SlidingBufferIterator: LegacyIterator requirements", "[SlidingBufferI
 TEST_CASE("SlidingBufferIterator: LegacyForwardIterator requirements",
           "[SlidingBufferIterator]")
 {
-    SlidingBuffer<int, 10> buf;
-    for (auto i = 0u; i < buf.capacity(); i++)
-        buf.push_back(i);
+    auto buf = create_buffer<int, 10>();
 
     SECTION("postfix operator++")
     {
@@ -1386,9 +1391,7 @@ TEST_CASE("SlidingBufferIterator: LegacyForwardIterator requirements",
 TEST_CASE("SlidingBufferIterator: LegacyBidirectionalIterator requirements",
           "[SlidingBufferIterator]")
 {
-    SlidingBuffer<int, 10> buf;
-    for (auto i = 0u; i < buf.capacity(); i++)
-        buf.push_back(i);
+    auto buf = create_buffer<int, 10>();
 
     SECTION("prefix operator--")
     {
@@ -1413,9 +1416,7 @@ TEST_CASE("SlidingBufferIterator: LegacyBidirectionalIterator requirements",
 TEST_CASE("SlidingBufferIterator: LegacyRandomAccessIterator requirements",
           "[SlidingBufferIterator]")
 {
-    SlidingBuffer<int, 10> buf;
-    for (auto i = 0u; i < buf.capacity(); i++)
-        buf.push_back(i);
+    auto buf = create_buffer<int, 10>();
 
     SECTION("operator+=")
     {
@@ -1498,7 +1499,7 @@ TEST_CASE("SlidingBufferIterator: LegacyRandomAccessIterator requirements",
 
         ++it;
         for (int i = -1; i < static_cast<int>(buf.size()) - 1; ++i)
-            REQUIRE(it[i] == buf[i + 1]);
+            REQUIRE(it[i] == buf[static_cast<std::size_t>(i + 1)]);
     }
 
     SECTION("Comparison operators")
@@ -1520,9 +1521,7 @@ TEST_CASE("SlidingBufferIterator: LegacyRandomAccessIterator requirements",
 
 TEST_CASE("SlidingBufferIterator: std::distance()", "[SlidingBufferIterator]")
 {
-    SlidingBuffer<int, 10> buf;
-    for (auto i = 0u; i < buf.capacity(); i++)
-        buf.push_back(i);
+    auto buf = create_buffer<int, 10>();
 
     REQUIRE(std::distance(buf.begin(), buf.begin()) == 0);
     REQUIRE(std::distance(buf.begin(), buf.begin() + 2) == 2);


### PR DESCRIPTION
## Why
There are some really annoying warnings which are spammed if compiling with clang.
Since we use gul includes all over, every include will emit these warnings.