### PR TITLE
CI: Update sync pipeline runner

### DIFF
--- a/.gitlab-ci/sync.yml
+++ b/.gitlab-ci/sync.yml
@@ -11,9 +11,9 @@ Github sync:
         # Key: GITLAB_ACCESS_TOKEN
         # Value: Access token from above
         # Set Protect variable and Mask variable
-        image: ubuntu:20.04
+        image: ubuntu:latest
         tags:
-                - ubuntu20
+                - docker
         script:
                 - apt update
                 - apt install -y git-core ca-certificates


### PR DESCRIPTION
[why]
The sync pipeline fails always.
There is no ubuntu20 runner anymore.

[how]
Be more generic, we just use git commands and do not care for OS details at all.